### PR TITLE
fix: typo in property name for storage V1 api group

### DIFF
--- a/Sources/SwiftkubeClient/API Groups/KubernetesClient+storage.v1.swift
+++ b/Sources/SwiftkubeClient/API Groups/KubernetesClient+storage.v1.swift
@@ -57,7 +57,7 @@ public extension KubernetesClient {
 		}
 	}
 
-	var sorageV1: StorageV1API {
+	var storageV1: StorageV1API {
 		StorageV1(self)
 	}
 }


### PR DESCRIPTION
Hello 👋 

First of all great work. 
It's my first time using the lib and i found it with a very amusing interface 😍 

I just found out a typo in the the property to access the storage and i thought i could contribute with this dummy fix and thank you for this.

So feel free to deny this simple PR, the main idea was to thank you for your work 🙇 

Please let me know if i can help you with something 🙏 
I use to be an iOS developer for several years, always enjoying backend and since things like PerfectSwift, Vapor and Kitura(no longer with us) appeared i decide to move back to backend and trying to push the usage of Swift on it, so i'm glad to help in what i can 😊 

Cheers