### PR TITLE
Explicit dependency on NIO

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,7 @@ let package = Package(
 		.package(name: "swift-log", url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.4.0")),
 		.package(name: "swift-metrics", url: "https://github.com/apple/swift-metrics.git", "1.0.0" ..< "3.0.0"),
 		.package(name: "Yams", url: "https://github.com/jpsim/Yams.git", .upToNextMajor(from: "4.0.0")),
+		.package(name: "NIO", url: "https://github.com/apple/swift-nio", .upToNextMajor(from: "2.0.0"))
 	],
 	targets: [
 		.target(
@@ -30,6 +31,8 @@ let package = Package(
 				.product(name: "Logging", package: "swift-log"),
 				.product(name: "Metrics", package: "swift-metrics"),
 				.product(name: "Yams", package: "Yams"),
+				.product(name: "NIO", package: "swift-nio"),
+				.product(name: "NIOFoundationCompat", package: "swift-nio"),
 			]
 		),
 		.testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
 		.package(name: "swift-log", url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.4.0")),
 		.package(name: "swift-metrics", url: "https://github.com/apple/swift-metrics.git", "1.0.0" ..< "3.0.0"),
 		.package(name: "Yams", url: "https://github.com/jpsim/Yams.git", .upToNextMajor(from: "4.0.0")),
-		.package(name: "NIO", url: "https://github.com/apple/swift-nio", .upToNextMajor(from: "2.0.0"))
+		.package(name: "swift-nio", url: "https://github.com/apple/swift-nio", .upToNextMajor(from: "2.0.0"))
 	],
 	targets: [
 		.target(

--- a/Sources/SwiftkubeClient/Watch/StreamingDelegate.swift
+++ b/Sources/SwiftkubeClient/Watch/StreamingDelegate.swift
@@ -18,6 +18,7 @@ import AsyncHTTPClient
 import Foundation
 import Logging
 import NIO
+import NIOFoundationCompat
 import NIOHTTP1
 import SwiftkubeModel
 


### PR DESCRIPTION
### Motivation

When compiling with Swift 5.5 on linux I get the following errors

```
$ docker run -it --rm -v (pwd):/app -w /app  swift:5.5.2-focal swift build -c release --static-swift-stdlib
/app/.build/checkouts/client/Sources/SwiftkubeClient/Client/GenericKubernetesClient.swift:335:14: error: no exact matches in call to initializer 
                let data = Data(buffer: byteBuffer)
                           ^
/app/.build/checkouts/client/Sources/SwiftkubeClient/Client/GenericKubernetesClient.swift:335:14: note: found candidate with type '(UnsafeBufferPointer<_>) -> Data'
                let data = Data(buffer: byteBuffer)
                           ^
/app/.build/checkouts/client/Sources/SwiftkubeClient/Client/GenericKubernetesClient.swift:335:14: note: found candidate with type '(UnsafeMutableBufferPointer<_>) -> Data'
                let data = Data(buffer: byteBuffer)
                           ^
/app/.build/checkouts/client/Sources/SwiftkubeClient/Discovery/KubernetesClient+Discovery.swift:153:14: error: no exact matches in call to initializer 
                let data = Data(buffer: byteBuffer)
                           ^
/app/.build/checkouts/client/Sources/SwiftkubeClient/Discovery/KubernetesClient+Discovery.swift:153:14: note: found candidate with type '(UnsafeBufferPointer<_>) -> Data'
                let data = Data(buffer: byteBuffer)
                           ^
/app/.build/checkouts/client/Sources/SwiftkubeClient/Discovery/KubernetesClient+Discovery.swift:153:14: note: found candidate with type '(UnsafeMutableBufferPointer<_>) -> Data'
                let data = Data(buffer: byteBuffer)
                           ^
/app/.build/checkouts/client/Sources/SwiftkubeClient/Watch/StreamingDelegate.swift:74:31: error: value of type 'ByteBuffer' has no member 'readData'
                        let data = streamingBuffer.readData(length: readableLine + 1)
```

In `StreamingDelegate.swift` we are importing and using methods from `NIO` and we are using API from `NIOFoundationCompat` without explicitly importing this package.

Neither `NIO`, nor `NIOFoundationCompat` are explicitly declared dependencies in `Package.swift`. Adding those fixes the compilation.

### Changes

Add explicit dependency on `NIO` and `NIOFoundationCompat`.

### Result

Compilation completes successfully on linux with Swift 5.5.2.

I remember vaguely that there was a recent change on how transitive dependencies are handled in Swift but I could not find any reference anymore.