### PR TITLE
Add option to retrieve logs without watching

### DIFF
--- a/Sources/SwiftkubeClient/Client/GenericKubernetesClient.swift
+++ b/Sources/SwiftkubeClient/Client/GenericKubernetesClient.swift
@@ -245,6 +245,21 @@ public extension GenericKubernetesClient where Resource: ScalableResource {
 	}
 }
 
+// MARK: - GenericKubernetesClient - logs
+
+internal extension GenericKubernetesClient {
+	func logs(in namespace: NamespaceSelector, name: String) throws -> EventLoopFuture<String> {
+		do {
+			let eventLoop = httpClient.eventLoopGroup.next()
+			let request = try makeRequest().in(namespace).toGet().resource(withName: name).subResource(.log).build()
+
+			return dispatchText(request: request, eventLoop: eventLoop)
+		} catch {
+			return httpClient.eventLoopGroup.next().makeFailedFuture(error)
+		}
+	}
+}
+
 // MARK: - GenericKubernetesClient + StatusHavingResource
 
 public extension GenericKubernetesClient where Resource: StatusHavingResource {
@@ -305,6 +320,18 @@ internal extension GenericKubernetesClient {
 			}
 	}
 
+	func dispatchText(request: HTTPClient.Request, eventLoop: EventLoop) -> EventLoopFuture<String> {
+		let startTime = DispatchTime.now().uptimeNanoseconds
+
+		return httpClient.execute(request: request, logger: logger)
+			.always { (result: Result<HTTPClient.Response, Error>) in
+				KubernetesClient.updateMetrics(startTime: startTime, request: request, result: result)
+			}
+			.flatMap { response in
+				self.handleText(response, eventLoop: eventLoop)
+			}
+	}
+
 	func dispatch<T: Decodable>(request: HTTPClient.Request, eventLoop: EventLoop) -> EventLoopFuture<ResourceOrStatus<T>> {
 		let startTime = DispatchTime.now().uptimeNanoseconds
 
@@ -319,6 +346,16 @@ internal extension GenericKubernetesClient {
 
 	func handle<T: Decodable>(_ response: HTTPClient.Response, eventLoop: EventLoop) -> EventLoopFuture<T> {
 		handleResourceOrStatus(response, eventLoop: eventLoop).flatMap { (result: ResourceOrStatus<T>) -> EventLoopFuture<T> in
+			guard case let ResourceOrStatus.resource(resource) = result else {
+				return eventLoop.makeFailedFuture(SwiftkubeClientError.decodingError("Expected resource type in response but got meta.v1.Status instead"))
+			}
+
+			return eventLoop.makeSucceededFuture(resource)
+		}
+	}
+
+	func handleText(_ response: HTTPClient.Response, eventLoop: EventLoop) -> EventLoopFuture<String> {
+		handleResourceOrStatusText(response, eventLoop: eventLoop).flatMap { (result: ResourceOrStatus<String>) -> EventLoopFuture<String> in
 			guard case let ResourceOrStatus.resource(resource) = result else {
 				return eventLoop.makeFailedFuture(SwiftkubeClientError.decodingError("Expected resource type in response but got meta.v1.Status instead"))
 			}
@@ -351,6 +388,24 @@ internal extension GenericKubernetesClient {
 		} else {
 			return eventLoop.makeFailedFuture(SwiftkubeClientError.decodingError("Error decoding \(T.self)"))
 		}
+	}
+
+	func handleResourceOrStatusText(_ response: HTTPClient.Response, eventLoop: EventLoop) -> EventLoopFuture<ResourceOrStatus<String>> {
+		guard let byteBuffer = response.body else {
+			return httpClient.eventLoopGroup.next().makeFailedFuture(SwiftkubeClientError.emptyResponse)
+		}
+
+		let data = Data(buffer: byteBuffer)
+
+		guard let logs = String(data: data, encoding: .utf8) else {
+			return httpClient.eventLoopGroup.next().makeFailedFuture(SwiftkubeClientError.decodingError("Error decoding string"))
+		}
+
+		if response.status.code >= 400 {
+			return eventLoop.makeFailedFuture(SwiftkubeClientError.decodingError("Error decoding string"))
+		}
+
+		return eventLoop.makeSucceededFuture(.resource(logs))
 	}
 }
 

--- a/Sources/SwiftkubeClient/Client/GenericKubernetesClient.swift
+++ b/Sources/SwiftkubeClient/Client/GenericKubernetesClient.swift
@@ -248,10 +248,10 @@ public extension GenericKubernetesClient where Resource: ScalableResource {
 // MARK: - GenericKubernetesClient - logs
 
 internal extension GenericKubernetesClient {
-	func logs(in namespace: NamespaceSelector, name: String) throws -> EventLoopFuture<String> {
+	func logs(in namespace: NamespaceSelector, name: String, container: String?) throws -> EventLoopFuture<String> {
 		do {
 			let eventLoop = httpClient.eventLoopGroup.next()
-			let request = try makeRequest().in(namespace).toGet().resource(withName: name).subResource(.log).build()
+			let request = try makeRequest().in(namespace).toLogs(pod: name, container: container).subResource(.log).build()
 
 			return dispatchText(request: request, eventLoop: eventLoop)
 		} catch {

--- a/Sources/SwiftkubeClient/Client/NamespacedGenericKubernetesClient+Pod.swift
+++ b/Sources/SwiftkubeClient/Client/NamespacedGenericKubernetesClient+Pod.swift
@@ -44,7 +44,8 @@ public extension NamespacedGenericKubernetesClient where Resource == core.v1.Pod
 	) throws -> EventLoopFuture<String> {
 		try super.logs(
 			in: namespace ?? .namespace(config.namespace),
-			name: name
+			name: name,
+			container: container
 		)
 	}
 }

--- a/Sources/SwiftkubeClient/Client/NamespacedGenericKubernetesClient+Pod.swift
+++ b/Sources/SwiftkubeClient/Client/NamespacedGenericKubernetesClient+Pod.swift
@@ -36,4 +36,16 @@ public extension NamespacedGenericKubernetesClient where Resource == core.v1.Pod
 			delegate: delegate
 		)
 	}
+
+	func logs(
+		in namespace: NamespaceSelector? = nil,
+		name: String,
+		container: String? = nil,
+		retryStrategy: RetryStrategy = RetryStrategy.never
+	) throws -> EventLoopFuture<String> {
+		try super.logs(
+			in: namespace ?? .namespace(config.namespace),
+			name: name
+		)
+	}
 }

--- a/Sources/SwiftkubeClient/Client/NamespacedGenericKubernetesClient+Pod.swift
+++ b/Sources/SwiftkubeClient/Client/NamespacedGenericKubernetesClient+Pod.swift
@@ -40,8 +40,7 @@ public extension NamespacedGenericKubernetesClient where Resource == core.v1.Pod
 	func logs(
 		in namespace: NamespaceSelector? = nil,
 		name: String,
-		container: String? = nil,
-		retryStrategy: RetryStrategy = RetryStrategy.never
+		container: String? = nil
 	) throws -> EventLoopFuture<String> {
 		try super.logs(
 			in: namespace ?? .namespace(config.namespace),

--- a/Sources/SwiftkubeClient/Client/RequestBuilder.swift
+++ b/Sources/SwiftkubeClient/Client/RequestBuilder.swift
@@ -23,7 +23,7 @@ import SwiftkubeModel
 // MARK: - ResourceType
 
 internal enum ResourceType {
-	case root, log, scale, status
+	case root, log, scale, status, logSync
 
 	var path: String {
 		switch self {
@@ -35,6 +35,8 @@ internal enum ResourceType {
 			return "/scale"
 		case .status:
 			return "/status"
+		case .logSync:
+			return "/log"
 		}
 	}
 }
@@ -138,7 +140,7 @@ internal class RequestBuilder {
 		}
 	}
 
-	var hasPayload: Bool = false
+	var hasPayload = false
 
 	var resourceName: String?
 	var requestBody: RequestBody? {
@@ -153,7 +155,7 @@ internal class RequestBuilder {
 	var listOptions: [ListOption]?
 	var readOptions: [ReadOption]?
 	var deleteOptions: meta.v1.DeleteOptions?
-	var watchFlag: Bool = false
+	var watchFlag = false
 
 	init(config: KubernetesClientConfig, gvr: GroupVersionResource) {
 		self.config = config

--- a/Sources/SwiftkubeClient/Client/RequestBuilder.swift
+++ b/Sources/SwiftkubeClient/Client/RequestBuilder.swift
@@ -23,7 +23,7 @@ import SwiftkubeModel
 // MARK: - ResourceType
 
 internal enum ResourceType {
-	case root, log, scale, status, logSync
+	case root, log, scale, status
 
 	var path: String {
 		switch self {
@@ -35,8 +35,6 @@ internal enum ResourceType {
 			return "/scale"
 		case .status:
 			return "/status"
-		case .logSync:
-			return "/log"
 		}
 	}
 }

--- a/Sources/SwiftkubeClient/Client/RequestBuilder.swift
+++ b/Sources/SwiftkubeClient/Client/RequestBuilder.swift
@@ -79,6 +79,7 @@ internal protocol MethodStep {
 	func toPost() -> PostStep
 	func toPut() -> PutStep
 	func toDelete() -> DeleteStep
+	func toLogs(pod: String, container: String?) -> GetStep
 }
 
 // MARK: - GetStep
@@ -218,6 +219,14 @@ extension RequestBuilder: MethodStep {
 	/// Set request method to  GET and notice the pod and container to follow for the pending request
 	/// - Returns:The builder instance as GetStep
 	func toFollow(pod: String, container: String?) -> GetStep {
+		method = .GET
+		resourceName = pod
+		containerName = container
+		subResourceType = .log
+		return self as GetStep
+	}
+
+	func toLogs(pod: String, container: String?) -> GetStep {
 		method = .GET
 		resourceName = pod
 		containerName = container

--- a/Sources/SwiftkubeClient/Watch/SwiftkubeClientTask.swift
+++ b/Sources/SwiftkubeClient/Watch/SwiftkubeClientTask.swift
@@ -46,7 +46,7 @@ public class SwiftkubeClientTask: SwiftkubeClientTaskDelegate {
 	let promise: EventLoopPromise<Void>
 	let retriesSequence: RetryStrategy.Iterator
 	let logger: Logger
-	var cancelled: Bool = false
+	var cancelled = false
 	var clientTask: HTTPClient.Task<Void>?
 
 	init(


### PR DESCRIPTION
This adds a parallel way to get logs other than the current follow logs option. It uses the same path to query the api but without the follow=true option
This returns the logs as plane text so a number of functions have been duplicated to handle this