### PR TITLE
adds suspend and unsuspend functions to Cronjob and implements PATCH

### DIFF
--- a/Sources/SwiftkubeClient/Client/GenericKubernetesClient.swift
+++ b/Sources/SwiftkubeClient/Client/GenericKubernetesClient.swift
@@ -42,7 +42,7 @@ public class GenericKubernetesClient<Resource: KubernetesAPIResource> {
 	internal let config: KubernetesClientConfig
 	internal let logger: Logger
 	internal let jsonDecoder: JSONDecoder
-
+	
 	/// Create a new instance of the generic client.
 	///
 	/// The `GroupVersionKind` of this client instance will be inferred by the generic constraint.
@@ -58,7 +58,7 @@ public class GenericKubernetesClient<Resource: KubernetesAPIResource> {
 	internal convenience init(httpClient: HTTPClient, config: KubernetesClientConfig, jsonDecoder: JSONDecoder, logger: Logger? = nil) {
 		self.init(httpClient: httpClient, config: config, gvr: GroupVersionResource(of: Resource.self)!, jsonDecoder: jsonDecoder, logger: logger)
 	}
-
+	
 	/// Create a new instance of the generic client for the given `GroupVersionKind`.
 	///
 	/// - Parameters:
@@ -92,13 +92,13 @@ public extension GenericKubernetesClient {
 		do {
 			let eventLoop = httpClient.eventLoopGroup.next()
 			let request = try makeRequest().in(namespace).toGet().resource(withName: name).with(options: options).build()
-
+			
 			return dispatch(request: request, eventLoop: eventLoop)
 		} catch {
 			return httpClient.eventLoopGroup.next().makeFailedFuture(error)
 		}
 	}
-
+	
 	/// Creates an API resource in the given namespace.
 	///
 	/// If the namespace is not specified then the default namespace defined in the `KubernetesClientConfig` will be used instead.
@@ -112,13 +112,13 @@ public extension GenericKubernetesClient {
 		do {
 			let eventLoop = httpClient.eventLoopGroup.next()
 			let request = try makeRequest().in(namespace).toPost().body(resource).build()
-
+			
 			return dispatch(request: request, eventLoop: eventLoop)
 		} catch {
 			return httpClient.eventLoopGroup.next().makeFailedFuture(error)
 		}
 	}
-
+	
 	/// Replaces, i.e. updates, an API resource with the given instance in the given namespace.
 	///
 	/// If the namespace is not specified then the default namespace defined in the `KubernetesClientConfig` will be used instead.
@@ -132,13 +132,13 @@ public extension GenericKubernetesClient {
 		do {
 			let eventLoop = httpClient.eventLoopGroup.next()
 			let request = try makeRequest().in(namespace).toPut().resource(withName: resource.name).body(.resource(payload: resource)).build()
-
+			
 			return dispatch(request: request, eventLoop: eventLoop)
 		} catch {
 			return httpClient.eventLoopGroup.next().makeFailedFuture(error)
 		}
 	}
-
+	
 	/// Replaces, i.e. updates, an API resource with the given instance in the given namespace.
 	///
 	/// If the namespace is not specified then the default namespace defined in the `KubernetesClientConfig` will be used instead.
@@ -152,13 +152,13 @@ public extension GenericKubernetesClient {
 		do {
 			let eventLoop = httpClient.eventLoopGroup.next()
 			let request = try makeRequest().in(namespace).toDelete().resource(withName: name).build()
-
+			
 			return dispatch(request: request, eventLoop: eventLoop)
 		} catch {
 			return httpClient.eventLoopGroup.next().makeFailedFuture(error)
 		}
 	}
-
+	
 	/// Deletes all API resources in the given namespace.
 	///
 	/// If the namespace is not specified then the default namespace defined in the `KubernetesClientConfig` will be used instead.
@@ -170,7 +170,7 @@ public extension GenericKubernetesClient {
 		do {
 			let eventLoop = httpClient.eventLoopGroup.next()
 			let request = try makeRequest().in(namespace).toDelete().build()
-
+			
 			return dispatch(request: request, eventLoop: eventLoop)
 		} catch {
 			return httpClient.eventLoopGroup.next().makeFailedFuture(error)
@@ -195,7 +195,7 @@ public extension GenericKubernetesClient where Resource: ListableResource {
 		do {
 			let eventLoop = httpClient.eventLoopGroup.next()
 			let request = try makeRequest().in(namespace).toGet().with(options: options).build()
-
+			
 			return dispatch(request: request, eventLoop: eventLoop)
 		} catch {
 			return httpClient.eventLoopGroup.next().makeFailedFuture(error)
@@ -218,13 +218,13 @@ public extension GenericKubernetesClient where Resource: ScalableResource {
 		do {
 			let eventLoop = httpClient.eventLoopGroup.next()
 			let request = try makeRequest().in(namespace).toGet().resource(withName: name).subResource(.scale).build()
-
+			
 			return dispatch(request: request, eventLoop: eventLoop)
 		} catch {
 			return httpClient.eventLoopGroup.next().makeFailedFuture(error)
 		}
 	}
-
+	
 	/// Replaces the resource's scale in the given namespace.
 	///
 	/// - Parameters:
@@ -237,7 +237,7 @@ public extension GenericKubernetesClient where Resource: ScalableResource {
 		do {
 			let eventLoop = httpClient.eventLoopGroup.next()
 			let request = try makeRequest().in(namespace).toPut().resource(withName: name).body(.subResource(type: .scale, payload: scale)).build()
-
+			
 			return dispatch(request: request, eventLoop: eventLoop)
 		} catch {
 			return httpClient.eventLoopGroup.next().makeFailedFuture(error)
@@ -275,13 +275,13 @@ public extension GenericKubernetesClient where Resource: StatusHavingResource {
 		do {
 			let eventLoop = httpClient.eventLoopGroup.next()
 			let request = try makeRequest().in(namespace).toGet().resource(withName: name).subResource(.status).build()
-
+			
 			return dispatch(request: request, eventLoop: eventLoop)
 		} catch {
 			return httpClient.eventLoopGroup.next().makeFailedFuture(error)
 		}
 	}
-
+	
 	/// Replaces the resource's status in the given namespace.
 	///
 	/// - Parameters:
@@ -294,7 +294,7 @@ public extension GenericKubernetesClient where Resource: StatusHavingResource {
 		do {
 			let eventLoop = httpClient.eventLoopGroup.next()
 			let request = try makeRequest().in(namespace).toPut().resource(withName: name).body(.subResource(type: .status, payload: resource)).build()
-
+			
 			return dispatch(request: request, eventLoop: eventLoop)
 		} catch {
 			return httpClient.eventLoopGroup.next().makeFailedFuture(error)
@@ -303,14 +303,14 @@ public extension GenericKubernetesClient where Resource: StatusHavingResource {
 }
 
 internal extension GenericKubernetesClient {
-
+	
 	func makeRequest() -> NamespaceStep {
 		RequestBuilder(config: config, gvr: gvr)
 	}
-
+	
 	func dispatch<T: Decodable>(request: HTTPClient.Request, eventLoop: EventLoop) -> EventLoopFuture<T> {
 		let startTime = DispatchTime.now().uptimeNanoseconds
-
+		
 		return httpClient.execute(request: request, logger: logger)
 			.always { (result: Result<HTTPClient.Response, Error>) in
 				KubernetesClient.updateMetrics(startTime: startTime, request: request, result: result)
@@ -334,7 +334,7 @@ internal extension GenericKubernetesClient {
 
 	func dispatch<T: Decodable>(request: HTTPClient.Request, eventLoop: EventLoop) -> EventLoopFuture<ResourceOrStatus<T>> {
 		let startTime = DispatchTime.now().uptimeNanoseconds
-
+		
 		return httpClient.execute(request: request, logger: logger)
 			.always { (result: Result<HTTPClient.Response, Error>) in
 				KubernetesClient.updateMetrics(startTime: startTime, request: request, result: result)
@@ -343,13 +343,13 @@ internal extension GenericKubernetesClient {
 				self.handleResourceOrStatus(response, eventLoop: eventLoop)
 			}
 	}
-
+	
 	func handle<T: Decodable>(_ response: HTTPClient.Response, eventLoop: EventLoop) -> EventLoopFuture<T> {
 		handleResourceOrStatus(response, eventLoop: eventLoop).flatMap { (result: ResourceOrStatus<T>) -> EventLoopFuture<T> in
 			guard case let ResourceOrStatus.resource(resource) = result else {
 				return eventLoop.makeFailedFuture(SwiftkubeClientError.decodingError("Expected resource type in response but got meta.v1.Status instead"))
 			}
-
+			
 			return eventLoop.makeSucceededFuture(resource)
 		}
 	}
@@ -368,7 +368,7 @@ internal extension GenericKubernetesClient {
 		guard let byteBuffer = response.body else {
 			return httpClient.eventLoopGroup.next().makeFailedFuture(SwiftkubeClientError.emptyResponse)
 		}
-
+		
 		let data = Data(buffer: byteBuffer)
 		jsonDecoder.userInfo[CodingUserInfoKey.apiVersion] = gvr.apiVersion
 		jsonDecoder.userInfo[CodingUserInfoKey.resources] = gvr.resource
@@ -380,7 +380,7 @@ internal extension GenericKubernetesClient {
 			}
 			return eventLoop.makeFailedFuture(SwiftkubeClientError.requestError(status))
 		}
-
+		
 		if let resource = try? jsonDecoder.decode(T.self, from: data) {
 			return eventLoop.makeSucceededFuture(.resource(resource))
 		} else if let status = try? jsonDecoder.decode(meta.v1.Status.self, from: data) {
@@ -454,18 +454,18 @@ public extension GenericKubernetesClient {
 		let request = try makeRequest().in(namespace).toWatch().with(options: options).build()
 		let watcher = ResourceWatcher(decoder: jsonDecoder, delegate: delegate)
 		let clientDelegate = ClientStreamingDelegate(watcher: watcher, logger: logger)
-
+		
 		let task = SwiftkubeClientTask(
 			client: httpClient,
 			request: request,
 			streamingDelegate: clientDelegate,
 			logger: logger
 		)
-
+		
 		task.schedule(in: TimeAmount.zero)
 		return task
 	}
-
+	
 	/// Follows the logs of the specified container.
 	///
 	/// Following the logs of a container opens a persistent connection to the API server. The connection is represented by a `HTTPClient.Task` instance, that acts
@@ -508,15 +508,43 @@ public extension GenericKubernetesClient {
 		let request = try makeRequest().in(namespace).toFollow(pod: name, container: container).build()
 		let watcher = LogWatcher(delegate: delegate)
 		let clientDelegate = ClientStreamingDelegate(watcher: watcher, logger: logger)
-
+		
 		let task = SwiftkubeClientTask(
 			client: httpClient,
 			request: request,
 			streamingDelegate: clientDelegate,
 			logger: logger
 		)
-
+		
 		task.schedule(in: TimeAmount.zero)
 		return task
 	}
+	
+	func suspend(
+	in namespace: NamespaceSelector,
+	   name: String) throws -> EventLoopFuture<Resource> {
+			  do {
+				  let eventLoop = httpClient.eventLoopGroup.next()
+				  let request = try makeRequest().in(namespace).toPatch().resource(withName: name).setBooleanPatchRFC6902(value: true, "/spec/suspend").build()
+				  
+
+				  return dispatch(request: request, eventLoop: eventLoop)
+			  } catch {
+				  return httpClient.eventLoopGroup.next().makeFailedFuture(error)
+			  }
+	   }
+
+	func unsuspend(
+		in namespace: NamespaceSelector,
+		name: String) throws -> EventLoopFuture<Resource> {
+			   do {
+				   let eventLoop = httpClient.eventLoopGroup.next()
+				   let request = try makeRequest().in(namespace).toPatch().resource(withName: name).setBooleanPatchRFC6902(value: false, "/spec/suspend").build()
+				   
+
+				   return dispatch(request: request, eventLoop: eventLoop)
+			   } catch {
+				   return httpClient.eventLoopGroup.next().makeFailedFuture(error)
+			   }
+		}
 }

--- a/Sources/SwiftkubeClient/Client/GenericKubernetesClient.swift
+++ b/Sources/SwiftkubeClient/Client/GenericKubernetesClient.swift
@@ -42,7 +42,7 @@ public class GenericKubernetesClient<Resource: KubernetesAPIResource> {
 	internal let config: KubernetesClientConfig
 	internal let logger: Logger
 	internal let jsonDecoder: JSONDecoder
-	
+
 	/// Create a new instance of the generic client.
 	///
 	/// The `GroupVersionKind` of this client instance will be inferred by the generic constraint.
@@ -58,7 +58,7 @@ public class GenericKubernetesClient<Resource: KubernetesAPIResource> {
 	internal convenience init(httpClient: HTTPClient, config: KubernetesClientConfig, jsonDecoder: JSONDecoder, logger: Logger? = nil) {
 		self.init(httpClient: httpClient, config: config, gvr: GroupVersionResource(of: Resource.self)!, jsonDecoder: jsonDecoder, logger: logger)
 	}
-	
+
 	/// Create a new instance of the generic client for the given `GroupVersionKind`.
 	///
 	/// - Parameters:
@@ -92,13 +92,13 @@ public extension GenericKubernetesClient {
 		do {
 			let eventLoop = httpClient.eventLoopGroup.next()
 			let request = try makeRequest().in(namespace).toGet().resource(withName: name).with(options: options).build()
-			
+
 			return dispatch(request: request, eventLoop: eventLoop)
 		} catch {
 			return httpClient.eventLoopGroup.next().makeFailedFuture(error)
 		}
 	}
-	
+
 	/// Creates an API resource in the given namespace.
 	///
 	/// If the namespace is not specified then the default namespace defined in the `KubernetesClientConfig` will be used instead.
@@ -112,13 +112,13 @@ public extension GenericKubernetesClient {
 		do {
 			let eventLoop = httpClient.eventLoopGroup.next()
 			let request = try makeRequest().in(namespace).toPost().body(resource).build()
-			
+
 			return dispatch(request: request, eventLoop: eventLoop)
 		} catch {
 			return httpClient.eventLoopGroup.next().makeFailedFuture(error)
 		}
 	}
-	
+
 	/// Replaces, i.e. updates, an API resource with the given instance in the given namespace.
 	///
 	/// If the namespace is not specified then the default namespace defined in the `KubernetesClientConfig` will be used instead.
@@ -132,13 +132,13 @@ public extension GenericKubernetesClient {
 		do {
 			let eventLoop = httpClient.eventLoopGroup.next()
 			let request = try makeRequest().in(namespace).toPut().resource(withName: resource.name).body(.resource(payload: resource)).build()
-			
+
 			return dispatch(request: request, eventLoop: eventLoop)
 		} catch {
 			return httpClient.eventLoopGroup.next().makeFailedFuture(error)
 		}
 	}
-	
+
 	/// Replaces, i.e. updates, an API resource with the given instance in the given namespace.
 	///
 	/// If the namespace is not specified then the default namespace defined in the `KubernetesClientConfig` will be used instead.
@@ -152,13 +152,13 @@ public extension GenericKubernetesClient {
 		do {
 			let eventLoop = httpClient.eventLoopGroup.next()
 			let request = try makeRequest().in(namespace).toDelete().resource(withName: name).build()
-			
+
 			return dispatch(request: request, eventLoop: eventLoop)
 		} catch {
 			return httpClient.eventLoopGroup.next().makeFailedFuture(error)
 		}
 	}
-	
+
 	/// Deletes all API resources in the given namespace.
 	///
 	/// If the namespace is not specified then the default namespace defined in the `KubernetesClientConfig` will be used instead.
@@ -170,7 +170,7 @@ public extension GenericKubernetesClient {
 		do {
 			let eventLoop = httpClient.eventLoopGroup.next()
 			let request = try makeRequest().in(namespace).toDelete().build()
-			
+
 			return dispatch(request: request, eventLoop: eventLoop)
 		} catch {
 			return httpClient.eventLoopGroup.next().makeFailedFuture(error)
@@ -195,7 +195,7 @@ public extension GenericKubernetesClient where Resource: ListableResource {
 		do {
 			let eventLoop = httpClient.eventLoopGroup.next()
 			let request = try makeRequest().in(namespace).toGet().with(options: options).build()
-			
+
 			return dispatch(request: request, eventLoop: eventLoop)
 		} catch {
 			return httpClient.eventLoopGroup.next().makeFailedFuture(error)
@@ -218,13 +218,13 @@ public extension GenericKubernetesClient where Resource: ScalableResource {
 		do {
 			let eventLoop = httpClient.eventLoopGroup.next()
 			let request = try makeRequest().in(namespace).toGet().resource(withName: name).subResource(.scale).build()
-			
+
 			return dispatch(request: request, eventLoop: eventLoop)
 		} catch {
 			return httpClient.eventLoopGroup.next().makeFailedFuture(error)
 		}
 	}
-	
+
 	/// Replaces the resource's scale in the given namespace.
 	///
 	/// - Parameters:
@@ -237,7 +237,7 @@ public extension GenericKubernetesClient where Resource: ScalableResource {
 		do {
 			let eventLoop = httpClient.eventLoopGroup.next()
 			let request = try makeRequest().in(namespace).toPut().resource(withName: name).body(.subResource(type: .scale, payload: scale)).build()
-			
+
 			return dispatch(request: request, eventLoop: eventLoop)
 		} catch {
 			return httpClient.eventLoopGroup.next().makeFailedFuture(error)
@@ -275,13 +275,13 @@ public extension GenericKubernetesClient where Resource: StatusHavingResource {
 		do {
 			let eventLoop = httpClient.eventLoopGroup.next()
 			let request = try makeRequest().in(namespace).toGet().resource(withName: name).subResource(.status).build()
-			
+
 			return dispatch(request: request, eventLoop: eventLoop)
 		} catch {
 			return httpClient.eventLoopGroup.next().makeFailedFuture(error)
 		}
 	}
-	
+
 	/// Replaces the resource's status in the given namespace.
 	///
 	/// - Parameters:
@@ -294,7 +294,7 @@ public extension GenericKubernetesClient where Resource: StatusHavingResource {
 		do {
 			let eventLoop = httpClient.eventLoopGroup.next()
 			let request = try makeRequest().in(namespace).toPut().resource(withName: name).body(.subResource(type: .status, payload: resource)).build()
-			
+
 			return dispatch(request: request, eventLoop: eventLoop)
 		} catch {
 			return httpClient.eventLoopGroup.next().makeFailedFuture(error)
@@ -303,14 +303,14 @@ public extension GenericKubernetesClient where Resource: StatusHavingResource {
 }
 
 internal extension GenericKubernetesClient {
-	
+
 	func makeRequest() -> NamespaceStep {
 		RequestBuilder(config: config, gvr: gvr)
 	}
-	
+
 	func dispatch<T: Decodable>(request: HTTPClient.Request, eventLoop: EventLoop) -> EventLoopFuture<T> {
 		let startTime = DispatchTime.now().uptimeNanoseconds
-		
+
 		return httpClient.execute(request: request, logger: logger)
 			.always { (result: Result<HTTPClient.Response, Error>) in
 				KubernetesClient.updateMetrics(startTime: startTime, request: request, result: result)
@@ -334,7 +334,7 @@ internal extension GenericKubernetesClient {
 
 	func dispatch<T: Decodable>(request: HTTPClient.Request, eventLoop: EventLoop) -> EventLoopFuture<ResourceOrStatus<T>> {
 		let startTime = DispatchTime.now().uptimeNanoseconds
-		
+
 		return httpClient.execute(request: request, logger: logger)
 			.always { (result: Result<HTTPClient.Response, Error>) in
 				KubernetesClient.updateMetrics(startTime: startTime, request: request, result: result)
@@ -343,13 +343,13 @@ internal extension GenericKubernetesClient {
 				self.handleResourceOrStatus(response, eventLoop: eventLoop)
 			}
 	}
-	
+
 	func handle<T: Decodable>(_ response: HTTPClient.Response, eventLoop: EventLoop) -> EventLoopFuture<T> {
 		handleResourceOrStatus(response, eventLoop: eventLoop).flatMap { (result: ResourceOrStatus<T>) -> EventLoopFuture<T> in
 			guard case let ResourceOrStatus.resource(resource) = result else {
 				return eventLoop.makeFailedFuture(SwiftkubeClientError.decodingError("Expected resource type in response but got meta.v1.Status instead"))
 			}
-			
+
 			return eventLoop.makeSucceededFuture(resource)
 		}
 	}
@@ -368,7 +368,7 @@ internal extension GenericKubernetesClient {
 		guard let byteBuffer = response.body else {
 			return httpClient.eventLoopGroup.next().makeFailedFuture(SwiftkubeClientError.emptyResponse)
 		}
-		
+
 		let data = Data(buffer: byteBuffer)
 		jsonDecoder.userInfo[CodingUserInfoKey.apiVersion] = gvr.apiVersion
 		jsonDecoder.userInfo[CodingUserInfoKey.resources] = gvr.resource
@@ -380,7 +380,7 @@ internal extension GenericKubernetesClient {
 			}
 			return eventLoop.makeFailedFuture(SwiftkubeClientError.requestError(status))
 		}
-		
+
 		if let resource = try? jsonDecoder.decode(T.self, from: data) {
 			return eventLoop.makeSucceededFuture(.resource(resource))
 		} else if let status = try? jsonDecoder.decode(meta.v1.Status.self, from: data) {
@@ -454,18 +454,18 @@ public extension GenericKubernetesClient {
 		let request = try makeRequest().in(namespace).toWatch().with(options: options).build()
 		let watcher = ResourceWatcher(decoder: jsonDecoder, delegate: delegate)
 		let clientDelegate = ClientStreamingDelegate(watcher: watcher, logger: logger)
-		
+
 		let task = SwiftkubeClientTask(
 			client: httpClient,
 			request: request,
 			streamingDelegate: clientDelegate,
 			logger: logger
 		)
-		
+
 		task.schedule(in: TimeAmount.zero)
 		return task
 	}
-	
+
 	/// Follows the logs of the specified container.
 	///
 	/// Following the logs of a container opens a persistent connection to the API server. The connection is represented by a `HTTPClient.Task` instance, that acts
@@ -508,43 +508,43 @@ public extension GenericKubernetesClient {
 		let request = try makeRequest().in(namespace).toFollow(pod: name, container: container).build()
 		let watcher = LogWatcher(delegate: delegate)
 		let clientDelegate = ClientStreamingDelegate(watcher: watcher, logger: logger)
-		
+
 		let task = SwiftkubeClientTask(
 			client: httpClient,
 			request: request,
 			streamingDelegate: clientDelegate,
 			logger: logger
 		)
-		
+
 		task.schedule(in: TimeAmount.zero)
 		return task
 	}
-	
-	func suspend(
-	in namespace: NamespaceSelector,
-	   name: String) throws -> EventLoopFuture<Resource> {
-			  do {
-				  let eventLoop = httpClient.eventLoopGroup.next()
-				  let request = try makeRequest().in(namespace).toPatch().resource(withName: name).setBooleanPatchRFC6902(value: true, "/spec/suspend").build()
-				  
 
-				  return dispatch(request: request, eventLoop: eventLoop)
-			  } catch {
-				  return httpClient.eventLoopGroup.next().makeFailedFuture(error)
-			  }
-	   }
+	func suspend(
+		in namespace: NamespaceSelector,
+		name: String
+	) throws -> EventLoopFuture<Resource> {
+		do {
+			let eventLoop = httpClient.eventLoopGroup.next()
+			let request = try makeRequest().in(namespace).toPatch().resource(withName: name).setBooleanPatchRFC6902(value: true, "/spec/suspend").build()
+
+			return dispatch(request: request, eventLoop: eventLoop)
+		} catch {
+			return httpClient.eventLoopGroup.next().makeFailedFuture(error)
+		}
+	}
 
 	func unsuspend(
 		in namespace: NamespaceSelector,
-		name: String) throws -> EventLoopFuture<Resource> {
-			   do {
-				   let eventLoop = httpClient.eventLoopGroup.next()
-				   let request = try makeRequest().in(namespace).toPatch().resource(withName: name).setBooleanPatchRFC6902(value: false, "/spec/suspend").build()
-				   
+		name: String
+	) throws -> EventLoopFuture<Resource> {
+		do {
+			let eventLoop = httpClient.eventLoopGroup.next()
+			let request = try makeRequest().in(namespace).toPatch().resource(withName: name).setBooleanPatchRFC6902(value: false, "/spec/suspend").build()
 
-				   return dispatch(request: request, eventLoop: eventLoop)
-			   } catch {
-				   return httpClient.eventLoopGroup.next().makeFailedFuture(error)
-			   }
+			return dispatch(request: request, eventLoop: eventLoop)
+		} catch {
+			return httpClient.eventLoopGroup.next().makeFailedFuture(error)
 		}
+	}
 }

--- a/Sources/SwiftkubeClient/Client/NamespacedGenericKubernetesClient+CronJob.swift
+++ b/Sources/SwiftkubeClient/Client/NamespacedGenericKubernetesClient+CronJob.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Thomas Horrobin
+// Copyright 2020 Swiftkube Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,12 +24,13 @@ public extension NamespacedGenericKubernetesClient where Resource == batch.v1bet
 		in namespace: NamespaceSelector,
 		name: String
 	) throws -> EventLoopFuture<Resource> {
-		return try super.suspend(in: namespace, name: name)
+		try super.suspend(in: namespace, name: name)
 	}
+
 	func unsuspend(
 		in namespace: NamespaceSelector,
 		name: String
 	) throws -> EventLoopFuture<Resource> {
-		return try super.unsuspend(in: namespace, name: name)
+		try super.unsuspend(in: namespace, name: name)
 	}
 }

--- a/Sources/SwiftkubeClient/Client/NamespacedGenericKubernetesClient+CronJob.swift
+++ b/Sources/SwiftkubeClient/Client/NamespacedGenericKubernetesClient+CronJob.swift
@@ -1,0 +1,35 @@
+//
+// Copyright 2022 Thomas Horrobin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import AsyncHTTPClient
+import NIO
+import SwiftkubeModel
+
+public extension NamespacedGenericKubernetesClient where Resource == batch.v1beta1.CronJob {
+
+	func suspend(
+		in namespace: NamespaceSelector,
+		name: String
+	) throws -> EventLoopFuture<Resource> {
+		return try super.suspend(in: namespace, name: name)
+	}
+	func unsuspend(
+		in namespace: NamespaceSelector,
+		name: String
+	) throws -> EventLoopFuture<Resource> {
+		return try super.unsuspend(in: namespace, name: name)
+	}
+}

--- a/Sources/SwiftkubeClient/Client/RequestBuilder.swift
+++ b/Sources/SwiftkubeClient/Client/RequestBuilder.swift
@@ -345,10 +345,11 @@ extension RequestBuilder: PatchStep {
 	}
 
 	/// Set the body payload for the pending request
-	/// - Parameter resource: The `KubernetesAPIResource` payload
+	/// - Parameter value: The value that will replace the current value
+	/// - Parameter path: The path to the value to be changed
 	/// - Returns: The builder instance as PatchStep
-	func setBooleanPatchRFC6902(value v: Bool, _ path: String) -> PatchStep {
-		patchBody = replaceBooleanRFC6902(path: path, value: v)
+	func setBooleanPatchRFC6902(value: Bool, _ path: String) -> PatchStep {
+		patchBody = replaceBooleanRFC6902(path: path, value: value)
 		return self as PatchStep
 	}
 }

--- a/Sources/SwiftkubeClient/Client/RequestBuilder.swift
+++ b/Sources/SwiftkubeClient/Client/RequestBuilder.swift
@@ -324,9 +324,7 @@ extension RequestBuilder: PutStep {
 }
 
 struct replaceBooleanRFC6902: Codable {
-	var op: String{
-		return "replace"
-	}
+	var op: String = "replace"
 	let path: String
 	let value: Bool
 }

--- a/Sources/SwiftkubeClient/Client/RequestBuilder.swift
+++ b/Sources/SwiftkubeClient/Client/RequestBuilder.swift
@@ -156,6 +156,7 @@ internal class RequestBuilder {
 			subResourceType = requestBody?.type
 		}
 	}
+
 	var patchBody: replaceBooleanRFC6902?
 
 	var subResourceType: ResourceType?
@@ -210,7 +211,7 @@ extension RequestBuilder: MethodStep {
 		method = .PUT
 		return self as PutStep
 	}
-	
+
 	/// Set request method to  PATCH for the pending request
 	/// - Returns:The builder instance as PatchStep
 	func toPatch() -> PatchStep {
@@ -323,13 +324,15 @@ extension RequestBuilder: PutStep {
 	}
 }
 
+// MARK: - replaceBooleanRFC6902
+
 struct replaceBooleanRFC6902: Codable {
 	var op: String = "replace"
 	let path: String
 	let value: Bool
 }
 
-// MARK: PatchStep
+// MARK: - RequestBuilder + PatchStep
 
 extension RequestBuilder: PatchStep {
 
@@ -340,7 +343,7 @@ extension RequestBuilder: PatchStep {
 		resourceName = name
 		return self as PatchStep
 	}
-	
+
 	/// Set the body payload for the pending request
 	/// - Parameter resource: The `KubernetesAPIResource` payload
 	/// - Returns: The builder instance as PatchStep
@@ -350,7 +353,7 @@ extension RequestBuilder: PatchStep {
 	}
 }
 
-// MARK: DeleteStep
+// MARK: - RequestBuilder + DeleteStep
 
 extension RequestBuilder: DeleteStep {
 
@@ -472,7 +475,7 @@ internal extension RequestBuilder {
 			let data = try encoder.encode(options)
 			return .data(data)
 		}
-		
+
 		if let patchBody = patchBody {
 			let data = try encoder.encode([patchBody])
 			return .data(data)

--- a/Sources/SwiftkubeClient/Client/RequestBuilder.swift
+++ b/Sources/SwiftkubeClient/Client/RequestBuilder.swift
@@ -454,6 +454,9 @@ internal extension RequestBuilder {
 		if let authorizationHeader = authentication?.authorizationHeader() {
 			headers.append(("Authorization", authorizationHeader))
 		}
+		if method == .PATCH {
+			headers.append(("Content-Type", "application/json-patch+json"))
+		}
 
 		return HTTPHeaders(headers)
 	}

--- a/Tests/SwiftkubeClientTests/RequestBuilderTests.swift
+++ b/Tests/SwiftkubeClientTests/RequestBuilderTests.swift
@@ -240,4 +240,14 @@ final class RequestBuilderTests: XCTestCase {
 		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/api/v1/namespaces/default/pods/test/scale")!)
 		XCTAssertEqual(request?.method, HTTPMethod.PUT)
 	}
+	
+	func testPatchCronjobScheduleInNamespace() {
+		gvr = GroupVersionResource(of: batch.v1.CronJob.self)!
+		let builder = RequestBuilder(config: config, gvr: gvr)
+//		let cronjob = batch.v1.CronJob(metadata: meta.v1.ObjectMeta(name: "cronjob123"), spec: nil, status: nil)
+		let request = try? builder.in(.default).toPatch().resource(withName: "cronjob123").setBooleanPatchRFC6902(value: true, "/spec/suspend").build()
+
+		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/apis/batch/v1/namespaces/default/cronjobs/cronjob123")!)
+		XCTAssertEqual(request?.method, HTTPMethod.PATCH)
+	}
 }

--- a/Tests/SwiftkubeClientTests/RequestBuilderTests.swift
+++ b/Tests/SwiftkubeClientTests/RequestBuilderTests.swift
@@ -244,7 +244,6 @@ final class RequestBuilderTests: XCTestCase {
 	func testPatchCronjobScheduleInNamespace() {
 		gvr = GroupVersionResource(of: batch.v1.CronJob.self)!
 		let builder = RequestBuilder(config: config, gvr: gvr)
-//		let cronjob = batch.v1.CronJob(metadata: meta.v1.ObjectMeta(name: "cronjob123"), spec: nil, status: nil)
 		let request = try? builder.in(.default).toPatch().resource(withName: "cronjob123").setBooleanPatchRFC6902(value: true, "/spec/suspend").build()
 
 		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/apis/batch/v1/namespaces/default/cronjobs/cronjob123")!)


### PR DESCRIPTION
This PR adds functions to make it easier and more reliable to update corncobs with Swiftkube.

Using PATCH is important as it enables us to update resources without concern for copying and uploading the entire resource. Which I have found to be error prone and messy. Implementing PATCH makes this much easier

@iabudiab as always, this may need some further work as I'm not as familiar with Swift as I'd like to be. And I'm not sure my implementation of PATCH is up to the standard it would need to be to be able to merged. So happy to rewrite if you have suggestions 