### PR TITLE
fixes bug when trying to fetch logs without following

### DIFF
--- a/Sources/SwiftkubeClient/Client/RequestBuilder.swift
+++ b/Sources/SwiftkubeClient/Client/RequestBuilder.swift
@@ -155,6 +155,7 @@ internal class RequestBuilder {
 	var readOptions: [ReadOption]?
 	var deleteOptions: meta.v1.DeleteOptions?
 	var watchFlag = false
+	var followFlag = false
 
 	init(config: KubernetesClientConfig, gvr: GroupVersionResource) {
 		self.config = config
@@ -223,6 +224,7 @@ extension RequestBuilder: MethodStep {
 		resourceName = pod
 		containerName = container
 		subResourceType = .log
+		followFlag = true
 		return self as GetStep
 	}
 
@@ -362,7 +364,7 @@ internal extension RequestBuilder {
 			add(queryItem: URLQueryItem(name: "watch", value: "true"))
 		}
 
-		if subResourceType == .log {
+		if followFlag {
 			add(queryItem: URLQueryItem(name: "follow", value: "true"))
 		}
 

--- a/Tests/SwiftkubeClientTests/RequestBuilderTests.swift
+++ b/Tests/SwiftkubeClientTests/RequestBuilderTests.swift
@@ -79,6 +79,22 @@ final class RequestBuilderTests: XCTestCase {
 		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/api/v1/namespaces/kube-system/pods/pod/log?follow=true&container=container")!)
 		XCTAssertEqual(request?.method, HTTPMethod.GET)
 	}
+	
+	func testLogsInNamespace() {
+		let builder = RequestBuilder(config: config, gvr: gvr)
+		let request = try? builder.in(.system).toLogs(pod: "pod", container: nil).build()
+
+		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/api/v1/namespaces/kube-system/pods/pod/log")!)
+		XCTAssertEqual(request?.method, HTTPMethod.GET)
+	}
+	
+	func testLogsWithContainerInNamespace() {
+		let builder = RequestBuilder(config: config, gvr: gvr)
+		let request = try? builder.in(.system).toLogs(pod: "pod", container: "container").build()
+
+		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/api/v1/namespaces/kube-system/pods/pod/log?container=container")!)
+		XCTAssertEqual(request?.method, HTTPMethod.GET)
+	}
 
 	func testGetWithListOptions_Eq() {
 		let builder = RequestBuilder(config: config, gvr: gvr)


### PR DESCRIPTION
After some investigation it turns out that sending `follow=true` in the query of any request to the Kubernetes API changes the behaviour of the response significantly. So it's critical that it is not sent if the request is not intended to stream the result. I've modified the code so we can easily distinguish between a "dump" of the logs and a stream of the logs