### PR TITLE
extend batch.v1.CronJob with generateJob function

### DIFF
--- a/Sources/SwiftkubeClient/Helpers/Hashes.swift
+++ b/Sources/SwiftkubeClient/Helpers/Hashes.swift
@@ -1,0 +1,36 @@
+//
+// Copyright 2020 Swiftkube Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+/// GenerateRandomHash returns a three character. I
+func GenerateRandomHash() -> String {
+	// We omit vowels from the set of available characters to reduce the chances
+	// of "bad words" being formed.
+	let alphanums = ["b", "c", "d", "f", "g", "h", "j", "k", "l", "m", "n", "p", "q", "r", "s", "t", "v", "w", "x", "z", "2", "4", "5", "6", "7", "8", "9"]
+	var seedAlphanum = alphanums.randomElement()!
+	var slug = seedAlphanum
+	var neededAlphanums = 2
+	while neededAlphanums > 0 {
+		let nextAlphanum = alphanums.randomElement()!
+		if nextAlphanum != seedAlphanum {
+			seedAlphanum = nextAlphanum
+			slug = slug + nextAlphanum
+			neededAlphanums -= 1
+		}
+	}
+	return slug
+}

--- a/Sources/SwiftkubeClient/Model/CronJob+batch.v1.swift
+++ b/Sources/SwiftkubeClient/Model/CronJob+batch.v1.swift
@@ -1,0 +1,42 @@
+//
+// Copyright 2020 Swiftkube Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import SwiftkubeModel
+
+// MARK: - createJobFromCronjobErrors
+
+enum createJobFromCronjobErrors: Error {
+	case jobSpecDoesntExist
+	case jobMetadataDoesntExist
+	case cronjobNameDoesntExist
+}
+
+public extension batch.v1.CronJob {
+	func generateJob() throws -> batch.v1.Job {
+		guard let jobTemplateSpec = spec?.jobTemplate.spec else { throw createJobFromCronjobErrors.jobSpecDoesntExist }
+		guard let name = name else { throw createJobFromCronjobErrors.cronjobNameDoesntExist }
+		let jobName = "\(name)-manual-\(GenerateRandomHash())"
+		guard let metadata = metadata else { throw createJobFromCronjobErrors.jobMetadataDoesntExist }
+		var existingMetadata = metadata
+		existingMetadata.name = jobName
+		var job = batch.v1.Job()
+		existingMetadata.resourceVersion = nil
+		job.spec = jobTemplateSpec
+		job.metadata = existingMetadata
+		return job
+	}
+}


### PR DESCRIPTION
There is a need to be able to trigger Cronjobs outside of the normal cron. This PR adds that functionality as an extension to `batch.v1.CronJob`