### PR TITLE
feat(authentication): support for exec kube config

### DIFF
--- a/Sources/SwiftkubeClient/Config/KubernetesClientConfig.swift
+++ b/Sources/SwiftkubeClient/Config/KubernetesClientConfig.swift
@@ -336,6 +336,72 @@ private extension AuthInfo {
 		} catch {
 			logger?.warning("Error initializing authentication from client certificate: \(error)")
 		}
+
+		#if os(Linux) || os(macOS)
+			do {
+				if let exec {
+					let outputData = try run(command: exec.command, arguments: exec.args)
+
+					let decoder = JSONDecoder()
+					decoder.dateDecodingStrategy = .iso8601
+					let credential = try decoder.decode(ExecCredential.self, from: outputData)
+
+					return .bearer(token: credential.status.token)
+				}
+			} catch {
+				logger?.warning("Error initializing authentication from exec \(error)")
+			}
+		#endif
 		return nil
 	}
 }
+
+// MARK: - ExecCredential
+
+// It seems that AWS doesn't implement properly the model for client.authentication.k8s.io/v1beta1
+// Acordingly with the doc https://kubernetes.io/docs/reference/config-api/client-authentication.v1beta1/
+// ExecCredential.Spec.interactive is required as long as the ones in the Status object.
+internal struct ExecCredential: Decodable {
+	let apiVersion: String
+	let kind: String
+	let spec: Spec
+	let status: Status
+}
+
+internal extension ExecCredential {
+	struct Spec: Decodable {
+		let cluster: Cluster?
+		let interactive: Bool?
+	}
+
+	struct Status: Decodable {
+		let expirationTimestamp: Date
+		let token: String
+		let clientCertificateData: String?
+		let clientKeyData: String?
+	}
+}
+
+#if os(Linux) || os(macOS)
+	internal func run(command: String, arguments: [String]? = nil) throws -> Data {
+		func run(_ command: String, _ arguments: [String]?) throws -> Data {
+			let task = Process()
+			task.executableURL = URL(fileURLWithPath: command)
+			task.arguments = arguments
+
+			let pipe = Pipe()
+			task.standardOutput = pipe
+
+			try task.run()
+
+			return pipe.fileHandleForReading.availableData
+		}
+
+		func resolve(command: String) throws -> String {
+			try String(decoding:
+				run("/usr/bin/which", ["\(command)"]), as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
+		}
+
+		return try run(resolve(command: command), arguments)
+	}
+#endif


### PR DESCRIPTION
Hello,

I saw this issue #5  and i remembered that i had locally a branch with this, so i decide to clean it up a little bit and give it some makeup 💄 and open a PR with it.

I have been using this privately, mostly because i'm not totally proud of it, as long as it works and there isn't much more to do, but please shout your ideas, suggestions, ...

Ideally there are a few validations that need to be done, as which version of the client.authentication.k8s.io resource should be used to decode.
Although the only resources versions that are available for now, are equal, which are [client.authentication.k8s.io/v1](https://kubernetes.io/docs/reference/config-api/client-authentication.v1/) and [client.authentication.k8s.io/v1beta1](https://kubernetes.io/docs/reference/config-api/client-authentication.v1beta1/), so it works for now.

Not sure what is your preference, but probably this https://github.com/ydataai/SwiftKubeClient/commit/c2ded6245b156ca8ac6436ffa4fe62bda25c2f4e#diff-ff7d732f3cc6e1355f72ed08c4c685417df831d6e7cfedb605418b494a87711bR361 should be moved into the models package.
I only use this for development, to connect remotely to AWS clusters when i need, in-cluster they use the environment inject into the Pod, so this is not necessary.

I'm more then welcome to change whatever is necessary 😊 

Thanks 🍻 

PS: @iabudiab and all the involved in it great work on the CRD support and so on 👏 
I know i was suppose to help and discuss and suddenly disappeared (sorry 😞), but unfortunately and working in a startup i didn't had time to dedicate to this, i haven't using that much Swift on the core, unfortunately 😢 , neither use your recent work, but i pretend to use this CRD support some day soon. 🙏 