### PR TITLE
Set the default response body buffer size for requests returning `String` to 10MB

### DIFF
--- a/Sources/SwiftkubeClient/Client/KubernetesRequest.swift
+++ b/Sources/SwiftkubeClient/Client/KubernetesRequest.swift
@@ -41,7 +41,7 @@ public struct KubernetesRequest {
 			url: url,
 			method: method,
 			headers: headers,
-			body: try buildSyncBody()
+			body: buildSyncBody()
 		)
 	}
 

--- a/Sources/SwiftkubeClient/Client/RequestHandlerType.swift
+++ b/Sources/SwiftkubeClient/Client/RequestHandlerType.swift
@@ -104,7 +104,7 @@ internal extension RequestHandlerType {
 
 			let byteBuffer: ByteBuffer
 			do {
-				byteBuffer = try await response.body.collect(upTo: expectedBytes ?? 1 * 1024 * 1024)
+				byteBuffer = try await response.body.collect(upTo: expectedBytes ?? 10 * 1024 * 1024)
 			} catch {
 				throw SwiftkubeClientError.clientError(error)
 			}


### PR DESCRIPTION
This does what the name suggests.

I ran into this when GETting logs of pods (instead of streaming them line by line) that had reasonably large amounts of logs after running for some time and erroring on response bodies larger than 1MB. With this change, I couldn't reproduce any errors anymore, even on very old pods with loads of logs.

Since on the other `dispatch` function with the generic return type the default response body size was set to 10MB, I assumed this might have been a typo and just hard-coded the 10 instead of a 1. Please let me know if this makes sense to you or if you'd prefer this to being solved differently.