### PR TITLE
bump SwiftkubeModel package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
 		),
 	],
 	dependencies: [
-		.package(name: "SwiftkubeModel", url: "https://github.com/swiftkube/model.git", .upToNextMinor(from: "0.8.0")),
+		.package(name: "SwiftkubeModel", url: "https://github.com/swiftkube/model.git", .upToNextMinor(from: "0.9.0")),
 		.package(name: "async-http-client", url: "https://github.com/swift-server/async-http-client.git", .upToNextMajor(from: "1.13.1")),
 		.package(name: "swift-log", url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.4.4")),
 		.package(name: "swift-metrics", url: "https://github.com/apple/swift-metrics.git", .upToNextMajor(from: "2.3.3")),


### PR DESCRIPTION
This obviously won't work. It's more of a nudge to say I need to use the new changes in SwiftkubeModel since v0.8.0

Normally I'd do more than this to help. I hate it when users dump tasks on maintainers, but there's little I can help with in this case 🤣

Thanks in advance!!!