### PR TITLE
Add optional `previous` & `timestamps` flags to log requests

### DIFF
--- a/Sources/SwiftkubeClient/Client/GenericKubernetesClient.swift
+++ b/Sources/SwiftkubeClient/Client/GenericKubernetesClient.swift
@@ -259,10 +259,10 @@ internal extension GenericKubernetesClient {
 	///
 	/// - Returns: The container logs as a single String.
 	/// - Throws: An error of type ``SwiftkubeClientError``.
-	func logs(in namespace: NamespaceSelector, name: String, container: String?) async throws -> String {
+	func logs(in namespace: NamespaceSelector, name: String, container: String?, previous: Bool = false, timestamps: Bool = false) async throws -> String {
 		let request = try makeRequest()
 			.in(namespace)
-			.toLogs(pod: name, container: container)
+			.toLogs(pod: name, container: container, previous: previous, timestamps: timestamps)
 			.subResource(.log)
 			.build()
 
@@ -427,9 +427,10 @@ public extension GenericKubernetesClient {
 		in namespace: NamespaceSelector,
 		name: String,
 		container: String?,
+		timestamps: Bool = false,
 		retryStrategy: RetryStrategy = RetryStrategy.never
 	) throws -> SwiftkubeClientTask<String> {
-		let request = try makeRequest().in(namespace).toFollow(pod: name, container: container).build()
+		let request = try makeRequest().in(namespace).toFollow(pod: name, container: container, timestamps: timestamps).build()
 
 		return SwiftkubeClientTask(
 			client: httpClient,

--- a/Sources/SwiftkubeClient/Client/GenericKubernetesClient.swift
+++ b/Sources/SwiftkubeClient/Client/GenericKubernetesClient.swift
@@ -256,6 +256,8 @@ internal extension GenericKubernetesClient {
 	///   - namespace: The namespace for this API request.
 	///   - name: The name of the pod.
 	///   - container: The name of the container.
+	///   - previous: Whether to request the logs of the previous instance of the container.
+	///   - timestamps: Whether to include timestamps on the log lines.
 	///
 	/// - Returns: The container logs as a single String.
 	/// - Throws: An error of type ``SwiftkubeClientError``.
@@ -420,6 +422,7 @@ public extension GenericKubernetesClient {
 	///   - namespace: The namespace for this API request.
 	///   - name: The name of the Pod.
 	///   - container: The name of the container.
+	///   - timestamps: Whether to include timestamps on the log lines.
 	///   - retryStrategy: An instance of a ``RetryStrategy`` configuration to use.
 	///
 	/// - Returns: A ``SwiftkubeClientTask`` instance, representing a streaming connection to the API server.

--- a/Sources/SwiftkubeClient/Client/NamespacedGenericKubernetesClient+Pod.swift
+++ b/Sources/SwiftkubeClient/Client/NamespacedGenericKubernetesClient+Pod.swift
@@ -63,6 +63,7 @@ public extension NamespacedGenericKubernetesClient where Resource == core.v1.Pod
 	///   - namespace: The namespace for this API request.
 	///   - name: The name of the Pod.
 	///   - container: The name of the container.
+	///   - timestamps: Whether to include timestamps on the log lines.
 	///   - retryStrategy: An instance of a ``RetryStrategy`` configuration to use.
 	///
 	/// - Returns: A ``SwiftkubeClientTask`` instance, representing a streaming connection to the API server.
@@ -90,6 +91,8 @@ public extension NamespacedGenericKubernetesClient where Resource == core.v1.Pod
 	///   - namespace: The namespace for this API request.
 	///   - name: The name of the pod.
 	///   - container: The name of the container.
+	///   - previous: Whether to request the logs of the previous instance of the container.
+	///   - timestamps: Whether to include timestamps on the log lines.
 	///
 	/// - Returns: The container logs as a single String.
 	/// - Throws: An error of type ``SwiftkubeClientError``.

--- a/Sources/SwiftkubeClient/Client/NamespacedGenericKubernetesClient+Pod.swift
+++ b/Sources/SwiftkubeClient/Client/NamespacedGenericKubernetesClient+Pod.swift
@@ -70,12 +70,14 @@ public extension NamespacedGenericKubernetesClient where Resource == core.v1.Pod
 		in namespace: NamespaceSelector? = nil,
 		name: String,
 		container: String? = nil,
+		timestamps: Bool = false,
 		retryStrategy: RetryStrategy = RetryStrategy.never
 	) throws -> SwiftkubeClientTask<String> {
 		try super.follow(
 			in: namespace ?? .namespace(config.namespace),
 			name: name,
 			container: container,
+			timestamps: timestamps,
 			retryStrategy: retryStrategy
 		)
 	}
@@ -94,12 +96,16 @@ public extension NamespacedGenericKubernetesClient where Resource == core.v1.Pod
 	func logs(
 		in namespace: NamespaceSelector? = nil,
 		name: String,
-		container: String? = nil
+		container: String? = nil,
+		previous: Bool = false,
+		timestamps: Bool = false
 	) async throws -> String {
 		try await super.logs(
 			in: namespace ?? .namespace(config.namespace),
 			name: name,
-			container: container
+			container: container,
+			previous: previous,
+			timestamps: timestamps
 		)
 	}
 }

--- a/Tests/SwiftkubeClientTests/RequestBuilderTests.swift
+++ b/Tests/SwiftkubeClientTests/RequestBuilderTests.swift
@@ -76,15 +76,23 @@ final class RequestBuilderTests: XCTestCase {
 
 	func testFollowInNamespace() {
 		let builder = RequestBuilder(config: config, gvr: gvr)
-		let request = try? builder.in(.system).toFollow(pod: "pod", container: "container").build()
+		let request = try? builder.in(.system).toFollow(pod: "pod", container: "container", timestamps: false).build()
 
 		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/api/v1/namespaces/kube-system/pods/pod/log?follow=true&container=container")!)
+		XCTAssertEqual(request?.method, HTTPMethod.GET)
+	}
+
+		func testFollowWithTimestampsInNamespace() {
+		let builder = RequestBuilder(config: config, gvr: gvr)
+		let request = try? builder.in(.system).toFollow(pod: "pod", container: "container", timestamps: true).build()
+
+		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/api/v1/namespaces/kube-system/pods/pod/log?follow=true&timestamps=true&container=container")!)
 		XCTAssertEqual(request?.method, HTTPMethod.GET)
 	}
 	
 	func testLogsInNamespace() {
 		let builder = RequestBuilder(config: config, gvr: gvr)
-		let request = try? builder.in(.system).toLogs(pod: "pod", container: nil).build()
+		let request = try? builder.in(.system).toLogs(pod: "pod", container: nil, previous: false, timestamps: false).build()
 
 		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/api/v1/namespaces/kube-system/pods/pod/log")!)
 		XCTAssertEqual(request?.method, HTTPMethod.GET)
@@ -92,9 +100,25 @@ final class RequestBuilderTests: XCTestCase {
 	
 	func testLogsWithContainerInNamespace() {
 		let builder = RequestBuilder(config: config, gvr: gvr)
-		let request = try? builder.in(.system).toLogs(pod: "pod", container: "container").build()
+		let request = try? builder.in(.system).toLogs(pod: "pod", container: "container", previous: false, timestamps: false).build()
 
 		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/api/v1/namespaces/kube-system/pods/pod/log?container=container")!)
+		XCTAssertEqual(request?.method, HTTPMethod.GET)
+	}
+
+	func testLogsWithPreviousInNamespace() {
+		let builder = RequestBuilder(config: config, gvr: gvr)
+		let request = try? builder.in(.system).toLogs(pod: "pod", container: nil, previous: true, timestamps: false).build()
+
+		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/api/v1/namespaces/kube-system/pods/pod/log?previous=true")!)
+		XCTAssertEqual(request?.method, HTTPMethod.GET)
+	}
+
+	func testLogsWithTimestampsInNamespace() {
+		let builder = RequestBuilder(config: config, gvr: gvr)
+		let request = try? builder.in(.system).toLogs(pod: "pod", container: nil, previous: false, timestamps: true).build()
+
+		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/api/v1/namespaces/kube-system/pods/pod/log?timestamps=true")!)
 		XCTAssertEqual(request?.method, HTTPMethod.GET)
 	}
 


### PR DESCRIPTION
This PR introduces the optional boolean arguments `previous` and `timestamps` to the `logs()` method and the optional boolean argument `timestamps` to the `follow()` method, to be able to request a pod's previously terminated container from the API and to be able to toggle timestamps on the log responses and streams on and off.

I've initialized all arguments as false to be able to just ignore them without breaking backwards compatibility. Please let me know if this makes sense to you the way it's implemented or if you'd prefer it differently.

And again, thanks for all the effort you're putting into this project! 🙂