### PR TITLE
fix(config-loader): do not set arguments if nil

### DIFF
--- a/Sources/SwiftkubeClient/Config/KubernetesClientConfig.swift
+++ b/Sources/SwiftkubeClient/Config/KubernetesClientConfig.swift
@@ -387,7 +387,7 @@ internal extension ExecCredential {
 		func run(_ command: String, _ arguments: [String]?) throws -> Data {
 			let task = Process()
 			task.executableURL = URL(fileURLWithPath: command)
-			task.arguments = arguments
+			arguments.flatMap { task.arguments = $0 }
 
 			let pipe = Pipe()
 			task.standardOutput = pipe


### PR DESCRIPTION
When setting the arguments for the task using an optional value, in this case nil, it was raising a bad access exception from the Task.

To avoid this i added a validation to the arguments settings those only when there is a non nil value.