### PR TITLE
Proxy URL support, gzip support, `tailLines` parameter on log requests, and some other minor tweaks

### DIFF
--- a/Sources/SwiftkubeClient/Client/GenericKubernetesClient.swift
+++ b/Sources/SwiftkubeClient/Client/GenericKubernetesClient.swift
@@ -259,13 +259,14 @@ internal extension GenericKubernetesClient {
 	///   - container: The name of the container.
 	///   - previous: Whether to request the logs of the previous instance of the container.
 	///   - timestamps: Whether to include timestamps on the log lines.
+	///   - tailLines: The number of log lines to load.
 	///
 	/// - Returns: The container logs as a single String.
 	/// - Throws: An error of type ``SwiftkubeClientError``.
-	func logs(in namespace: NamespaceSelector, name: String, container: String?, previous: Bool = false, timestamps: Bool = false) async throws -> String {
+	func logs(in namespace: NamespaceSelector, name: String, container: String?, previous: Bool = false, timestamps: Bool = false, tailLines: Int? = nil) async throws -> String {
 		let request = try makeRequest()
 			.in(namespace)
-			.toLogs(pod: name, container: container, previous: previous, timestamps: timestamps)
+			.toLogs(pod: name, container: container, previous: previous, timestamps: timestamps, tailLines: tailLines)
 			.subResource(.log)
 			.build()
 
@@ -424,6 +425,7 @@ public extension GenericKubernetesClient {
 	///   - name: The name of the Pod.
 	///   - container: The name of the container.
 	///   - timestamps: Whether to include timestamps on the log lines.
+	///   - tailLines: The number of log lines to load.
 	///   - retryStrategy: An instance of a ``RetryStrategy`` configuration to use.
 	///
 	/// - Returns: A ``SwiftkubeClientTask`` instance, representing a streaming connection to the API server.
@@ -432,9 +434,10 @@ public extension GenericKubernetesClient {
 		name: String,
 		container: String?,
 		timestamps: Bool = false,
+		tailLines: Int? = nil,
 		retryStrategy: RetryStrategy = RetryStrategy.never
 	) async throws -> SwiftkubeClientTask<String> {
-		let request = try makeRequest().in(namespace).toFollow(pod: name, container: container, timestamps: timestamps).build()
+		let request = try makeRequest().in(namespace).toFollow(pod: name, container: container, timestamps: timestamps, tailLines: tailLines).build()
 
 		return SwiftkubeClientTask(
 			client: httpClient,

--- a/Sources/SwiftkubeClient/Client/KubernetesClient.swift
+++ b/Sources/SwiftkubeClient/Client/KubernetesClient.swift
@@ -186,7 +186,8 @@ public actor KubernetesClient {
 			configuration: HTTPClient.Configuration(
 				tlsConfiguration: tlsConfiguration,
 				redirectConfiguration: config.redirectConfiguration,
-				timeout: config.timeout
+				timeout: config.timeout,
+				decompression: config.gzip ? .enabled(limit: .none) : .disabled
 			)
 		)
 	}

--- a/Sources/SwiftkubeClient/Client/NamespacedGenericKubernetesClient+Pod.swift
+++ b/Sources/SwiftkubeClient/Client/NamespacedGenericKubernetesClient+Pod.swift
@@ -64,6 +64,7 @@ public extension NamespacedGenericKubernetesClient where Resource == core.v1.Pod
 	///   - name: The name of the Pod.
 	///   - container: The name of the container.
 	///   - timestamps: Whether to include timestamps on the log lines.
+	///   - tailLines: The number of log lines to load.
 	///   - retryStrategy: An instance of a ``RetryStrategy`` configuration to use.
 	///
 	/// - Returns: A ``SwiftkubeClientTask`` instance, representing a streaming connection to the API server.
@@ -72,6 +73,7 @@ public extension NamespacedGenericKubernetesClient where Resource == core.v1.Pod
 		name: String,
 		container: String? = nil,
 		timestamps: Bool = false,
+		tailLines: Int? = nil,
 		retryStrategy: RetryStrategy = RetryStrategy.never
 	) async throws -> SwiftkubeClientTask<String> {
 		try await client.follow(
@@ -79,6 +81,7 @@ public extension NamespacedGenericKubernetesClient where Resource == core.v1.Pod
 			name: name,
 			container: container,
 			timestamps: timestamps,
+			tailLines: tailLines,
 			retryStrategy: retryStrategy
 		)
 	}
@@ -93,6 +96,7 @@ public extension NamespacedGenericKubernetesClient where Resource == core.v1.Pod
 	///   - container: The name of the container.
 	///   - previous: Whether to request the logs of the previous instance of the container.
 	///   - timestamps: Whether to include timestamps on the log lines.
+	///   - tailLines: The number of log lines to load.
 	///
 	/// - Returns: The container logs as a single String.
 	/// - Throws: An error of type ``SwiftkubeClientError``.
@@ -101,14 +105,16 @@ public extension NamespacedGenericKubernetesClient where Resource == core.v1.Pod
 		name: String,
 		container: String? = nil,
 		previous: Bool = false,
-		timestamps: Bool = false
+		timestamps: Bool = false,
+		tailLines: Int? = nil
 	) async throws -> String {
 		try await client.logs(
 			in: namespace ?? .namespace(config.namespace),
 			name: name,
 			container: container,
 			previous: previous,
-			timestamps: timestamps
+			timestamps: timestamps,
+			tailLines: tailLines
 		)
 	}
 }

--- a/Sources/SwiftkubeClient/Client/RequestBuilder.swift
+++ b/Sources/SwiftkubeClient/Client/RequestBuilder.swift
@@ -417,6 +417,10 @@ internal extension RequestBuilder {
 			headers.append(("Authorization", authorizationHeader))
 		}
 
+		if config.gzip {
+			headers.append(("Accept-Encoding", "gzip"))
+		}
+
 		return HTTPHeaders(headers)
 	}
 }

--- a/Sources/SwiftkubeClient/Client/Selectors.swift
+++ b/Sources/SwiftkubeClient/Client/Selectors.swift
@@ -76,6 +76,8 @@ public enum LabelSelectorRequirement: Hashable, Sendable {
 	case notIn([String: [String]])
 	/// A label must exist.
 	case exists([String])
+	/// A label must not exist.
+	case doesNotExist([String])
 
 	internal var value: String {
 		switch self {
@@ -88,6 +90,8 @@ public enum LabelSelectorRequirement: Hashable, Sendable {
 		case let .notIn(labels):
 			return labels.asQueryParam(joiner: "notin")
 		case let .exists(labels):
+			return labels.joined(separator: ",")
+		case let .doesNotExist(labels):
 			return labels.joined(separator: ",")
 		}
 	}

--- a/Sources/SwiftkubeClient/Config/KubeConfig.swift
+++ b/Sources/SwiftkubeClient/Config/KubeConfig.swift
@@ -52,7 +52,22 @@ public struct KubeConfig: Codable, Sendable {
 // MARK: - Cluster
 
 /// Cluster contains information about how to communicate with a kubernetes cluster.
-public struct Cluster: Codable, Sendable {
+public struct Cluster: Codable, Sendable, Hashable, Equatable {
+	public init(
+		server: String,
+		tlsServerName: String? = nil,
+		insecureSkipTLSVerify: Bool? = nil,
+		certificateAuthority: String? = nil,
+		certificateAuthorityData: Data? = nil,
+		proxyURL: String? = nil
+	) {
+		self.server = server
+		self.tlsServerName = tlsServerName
+		self.insecureSkipTLSVerify = insecureSkipTLSVerify
+		self.certificateAuthority = certificateAuthority
+		self.certificateAuthorityData = certificateAuthorityData
+		self.proxyURL = proxyURL
+	}
 
 	enum CodingKeys: String, CodingKey {
 		case server
@@ -85,7 +100,36 @@ public struct Cluster: Codable, Sendable {
 // MARK: - AuthInfo
 
 /// AuthInfo contains information that describes identity information.  This is use to tell the kubernetes cluster who you are.
-public struct AuthInfo: Codable, Sendable {
+public struct AuthInfo: Codable, Sendable, Hashable, Equatable {
+	public init(
+		clientCertificate: String? = nil,
+		clientCertificateData: Data? = nil,
+		clientKey: String? = nil,
+		clientKeyData: Data? = nil,
+		token: String? = nil,
+		tokenFile: String? = nil,
+		impersonate: String? = nil,
+		impersonateGroups: [String]? = nil,
+		impersonateUserExtra: [String: String]? = nil,
+		username: String? = nil,
+		password: String? = nil,
+		authProvider: AuthProviderConfig? = nil,
+		exec: ExecConfig? = nil
+	) {
+		self.clientCertificate = clientCertificate
+		self.clientCertificateData = clientCertificateData
+		self.clientKey = clientKey
+		self.clientKeyData = clientKeyData
+		self.token = token
+		self.tokenFile = tokenFile
+		self.impersonate = impersonate
+		self.impersonateGroups = impersonateGroups
+		self.impersonateUserExtra = impersonateUserExtra
+		self.username = username
+		self.password = password
+		self.authProvider = authProvider
+		self.exec = exec
+	}
 
 	enum CodingKeys: String, CodingKey {
 		case clientCertificate = "client-certificate"
@@ -201,7 +245,7 @@ public struct NamedAuthInfo: Codable, Sendable {
 // MARK: - AuthProviderConfig
 
 /// AuthProviderConfig holds the configuration for a specified auth provider.
-public struct AuthProviderConfig: Codable, Sendable {
+public struct AuthProviderConfig: Codable, Sendable, Hashable, Equatable {
 
 	/// Name is the nickname for this AuthProviderConfig.
 	public var name: String
@@ -215,7 +259,7 @@ public struct AuthProviderConfig: Codable, Sendable {
 ///  ExecConfig specifies a command to provide client credentials.
 ///  The command is exec'd and outputs structured stdout holding credentials.
 ///  See the client.authentication.k8s.io API group for specifications of the exact input and output format
-public struct ExecConfig: Codable, Sendable {
+public struct ExecConfig: Codable, Sendable, Hashable, Equatable {
 	/// Command to execute.
 	public var command: String
 
@@ -233,7 +277,7 @@ public struct ExecConfig: Codable, Sendable {
 // MARK: - ExecEnvVar
 
 /// ExecEnvVar is used for setting environment variables when executing an exec-based credential plugin.
-public struct ExecEnvVar: Codable, Sendable {
+public struct ExecEnvVar: Codable, Sendable, Hashable, Equatable {
 
 	/// Variable name.
 	public var name: String

--- a/Sources/SwiftkubeClient/Config/KubeConfig.swift
+++ b/Sources/SwiftkubeClient/Config/KubeConfig.swift
@@ -272,6 +272,29 @@ public struct ExecConfig: Codable, Sendable, Hashable, Equatable {
 
 	/// Preferred input version of the ExecInfo. The returned ExecCredentials MUST use the same encoding version as the input.
 	public var apiVersion: String
+
+	/// This text is shown to the user when the executable doesn't seem to be
+	/// present. For example, `brew install foo-cli` might be a good InstallHint for
+	/// foo-cli on Mac OS systems.
+	public var installHint: String?
+
+	/// ProvideClusterInfo determines whether or not to provide cluster information,
+	/// which could potentially contain very large CA data, to this exec plugin as a
+	/// part of the KUBERNETES_EXEC_INFO environment variable. By default, it is set
+	/// to false. Package k8s.io/client-go/tools/auth/exec provides helper methods for
+	/// reading this environment variable.
+	public var provideClusterInfo: Bool?
+
+	/// InteractiveMode determines this plugin's relationship with standard input. Valid
+	/// values are "Never" (this exec plugin never uses standard input), "IfAvailable" (this
+	/// exec plugin wants to use standard input if it is available), or "Always" (this exec
+	/// plugin requires standard input to function). See ExecInteractiveMode values for more
+	/// details.
+	///
+	/// If APIVersion is client.authentication.k8s.io/v1alpha1 or
+	/// client.authentication.k8s.io/v1beta1, then this field is optional and defaults
+	/// to "IfAvailable" when unset. Otherwise, this field is required.
+	public var interactiveMode: String?
 }
 
 // MARK: - ExecEnvVar

--- a/Sources/SwiftkubeClient/Config/KubernetesClientConfig.swift
+++ b/Sources/SwiftkubeClient/Config/KubernetesClientConfig.swift
@@ -449,20 +449,20 @@ private extension AuthInfo {
 // It seems that AWS doesn't implement properly the model for client.authentication.k8s.io/v1beta1
 // Acordingly with the doc https://kubernetes.io/docs/reference/config-api/client-authentication.v1beta1/
 // ExecCredential.Spec.interactive is required as long as the ones in the Status object.
-internal struct ExecCredential: Decodable {
+public struct ExecCredential: Codable {
 	let apiVersion: String
 	let kind: String
 	let spec: Spec
 	let status: Status
 }
 
-internal extension ExecCredential {
-	struct Spec: Decodable {
+public extension ExecCredential {
+	struct Spec: Codable {
 		let cluster: Cluster?
 		let interactive: Bool?
 	}
 
-	struct Status: Decodable {
+	struct Status: Codable {
 		let expirationTimestamp: Date
 		let token: String
 		let clientCertificateData: String?

--- a/Sources/SwiftkubeClient/Config/KubernetesClientConfig.swift
+++ b/Sources/SwiftkubeClient/Config/KubernetesClientConfig.swift
@@ -39,6 +39,8 @@ public struct KubernetesClientConfig: Sendable {
 	public let timeout: HTTPClient.Configuration.Timeout
 	/// The default redirect configuration for the underlying `HTTPCLient`.
 	public let redirectConfiguration: HTTPClient.Configuration.RedirectConfiguration
+	/// URL to the proxy to be used for all requests made by this client.
+	public let proxyURL: URL?
 	/// Whether to request and decode gzipped responses from the API server.
 	public let gzip: Bool
 
@@ -50,6 +52,7 @@ public struct KubernetesClientConfig: Sendable {
 		insecureSkipTLSVerify: Bool,
 		timeout: HTTPClient.Configuration.Timeout,
 		redirectConfiguration: HTTPClient.Configuration.RedirectConfiguration,
+		proxyURL: URL? = nil,
 		gzip: Bool = false
 	) {
 		self.masterURL = masterURL
@@ -59,6 +62,7 @@ public struct KubernetesClientConfig: Sendable {
 		self.insecureSkipTLSVerify = insecureSkipTLSVerify
 		self.timeout = timeout
 		self.redirectConfiguration = redirectConfiguration
+		self.proxyURL = proxyURL
 		self.gzip = gzip
 	}
 }
@@ -209,7 +213,8 @@ internal struct StringConfigLoader: KubernetesClientConfigLoader {
 			trustRoots: cluster.trustRoots(logger: logger),
 			insecureSkipTLSVerify: cluster.insecureSkipTLSVerify ?? true,
 			timeout: timeout,
-			redirectConfiguration: redirectConfiguration
+			redirectConfiguration: redirectConfiguration,
+			proxyURL: cluster.proxyURL.flatMap { URL(string: $0) }
 		)
 	}
 }
@@ -266,7 +271,8 @@ internal struct URLConfigLoader: KubernetesClientConfigLoader {
 			trustRoots: cluster.trustRoots(logger: logger),
 			insecureSkipTLSVerify: cluster.insecureSkipTLSVerify ?? true,
 			timeout: timeout,
-			redirectConfiguration: redirectConfiguration
+			redirectConfiguration: redirectConfiguration,
+			proxyURL: cluster.proxyURL.flatMap { URL(string: $0) }
 		)
 	}
 }
@@ -336,7 +342,8 @@ internal struct ServiceAccountConfigLoader: KubernetesClientConfigLoader {
 			trustRoots: trustRoots,
 			insecureSkipTLSVerify: trustRoots == nil,
 			timeout: timeout,
-			redirectConfiguration: redirectConfiguration
+			redirectConfiguration: redirectConfiguration,
+			proxyURL: nil
 		)
 	}
 

--- a/Sources/SwiftkubeClient/Config/KubernetesClientConfig.swift
+++ b/Sources/SwiftkubeClient/Config/KubernetesClientConfig.swift
@@ -39,6 +39,8 @@ public struct KubernetesClientConfig: Sendable {
 	public let timeout: HTTPClient.Configuration.Timeout
 	/// The default redirect configuration for the underlying `HTTPCLient`.
 	public let redirectConfiguration: HTTPClient.Configuration.RedirectConfiguration
+	/// Whether to request and decode gzipped responses from the API server.
+	public let gzip: Bool
 
 	public init(
 		masterURL: URL,
@@ -47,7 +49,8 @@ public struct KubernetesClientConfig: Sendable {
 		trustRoots: NIOSSLTrustRoots?,
 		insecureSkipTLSVerify: Bool,
 		timeout: HTTPClient.Configuration.Timeout,
-		redirectConfiguration: HTTPClient.Configuration.RedirectConfiguration
+		redirectConfiguration: HTTPClient.Configuration.RedirectConfiguration,
+		gzip: Bool = false
 	) {
 		self.masterURL = masterURL
 		self.namespace = namespace
@@ -56,6 +59,7 @@ public struct KubernetesClientConfig: Sendable {
 		self.insecureSkipTLSVerify = insecureSkipTLSVerify
 		self.timeout = timeout
 		self.redirectConfiguration = redirectConfiguration
+		self.gzip = gzip
 	}
 }
 

--- a/Tests/SwiftkubeClientTests/RequestBuilderTests.swift
+++ b/Tests/SwiftkubeClientTests/RequestBuilderTests.swift
@@ -34,7 +34,8 @@ final class RequestBuilderTests: XCTestCase {
 			trustRoots: nil,
 			insecureSkipTLSVerify: false,
 			timeout: .init(connect: .seconds(1), read: .seconds(5)),
-			redirectConfiguration: .disallow
+			redirectConfiguration: .disallow,
+			proxyURL: nil
 		)
 
 		gvr = GroupVersionResource(of: core.v1.Pod.self)!

--- a/Tests/SwiftkubeClientTests/RequestBuilderTests.swift
+++ b/Tests/SwiftkubeClientTests/RequestBuilderTests.swift
@@ -28,7 +28,7 @@ final class RequestBuilderTests: XCTestCase {
 
 	override func setUp() {
 		config = KubernetesClientConfig(
-			masterURL: URL(string: "https://kubernetesmaster")!,
+			masterURL: URL(string: "https://kubernetes/master")!,
 			namespace: "default",
 			authentication: .basicAuth(username: "test", password: "test"),
 			trustRoots: nil,
@@ -44,12 +44,12 @@ final class RequestBuilderTests: XCTestCase {
 		let builder = RequestBuilder(config: config, gvr: gvr)
 		var request = try? builder.in(.default).toGet().build()
 
-		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/api/v1/namespaces/default/pods")!)
+		XCTAssertEqual(request?.url, URL(string: "https://kubernetes/master/api/v1/namespaces/default/pods")!)
 		XCTAssertEqual(request?.method, HTTPMethod.GET)
 
 		request = try? builder.in(.system).toGet().build()
 
-		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/api/v1/namespaces/kube-system/pods")!)
+		XCTAssertEqual(request?.url, URL(string: "https://kubernetes/master/api/v1/namespaces/kube-system/pods")!)
 		XCTAssertEqual(request?.method, HTTPMethod.GET)
 	}
 
@@ -57,7 +57,7 @@ final class RequestBuilderTests: XCTestCase {
 		let builder = RequestBuilder(config: config, gvr: gvr)
 		let request = try? builder.in(.allNamespaces).toGet().build()
 
-		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/api/v1/pods")!)
+		XCTAssertEqual(request?.url, URL(string: "https://kubernetes/master/api/v1/pods")!)
 		XCTAssertEqual(request?.method, HTTPMethod.GET)
 	}
 
@@ -65,60 +65,60 @@ final class RequestBuilderTests: XCTestCase {
 		let builder = RequestBuilder(config: config, gvr: gvr)
 		var request = try? builder.in(.default).toGet().resource(withName: "test").build()
 
-		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/api/v1/namespaces/default/pods/test")!)
+		XCTAssertEqual(request?.url, URL(string: "https://kubernetes/master/api/v1/namespaces/default/pods/test")!)
 		XCTAssertEqual(request?.method, HTTPMethod.GET)
 
 		request = try? builder.in(.system).toGet().build()
 
-		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/api/v1/namespaces/kube-system/pods/test")!)
+		XCTAssertEqual(request?.url, URL(string: "https://kubernetes/master/api/v1/namespaces/kube-system/pods/test")!)
 		XCTAssertEqual(request?.method, HTTPMethod.GET)
 	}
 
 	func testFollowInNamespace() {
 		let builder = RequestBuilder(config: config, gvr: gvr)
-		let request = try? builder.in(.system).toFollow(pod: "pod", container: "container", timestamps: false).build()
+		let request = try? builder.in(.system).toFollow(pod: "pod", container: "container", timestamps: false, tailLines: nil).build()
 
-		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/api/v1/namespaces/kube-system/pods/pod/log?follow=true&container=container")!)
+		XCTAssertEqual(request?.url, URL(string: "https://kubernetes/master/api/v1/namespaces/kube-system/pods/pod/log?follow=true&container=container")!)
 		XCTAssertEqual(request?.method, HTTPMethod.GET)
 	}
 
 		func testFollowWithTimestampsInNamespace() {
 		let builder = RequestBuilder(config: config, gvr: gvr)
-		let request = try? builder.in(.system).toFollow(pod: "pod", container: "container", timestamps: true).build()
+		let request = try? builder.in(.system).toFollow(pod: "pod", container: "container", timestamps: true, tailLines: nil).build()
 
-		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/api/v1/namespaces/kube-system/pods/pod/log?follow=true&timestamps=true&container=container")!)
+		XCTAssertEqual(request?.url, URL(string: "https://kubernetes/master/api/v1/namespaces/kube-system/pods/pod/log?follow=true&timestamps=true&container=container")!)
 		XCTAssertEqual(request?.method, HTTPMethod.GET)
 	}
 	
 	func testLogsInNamespace() {
 		let builder = RequestBuilder(config: config, gvr: gvr)
-		let request = try? builder.in(.system).toLogs(pod: "pod", container: nil, previous: false, timestamps: false).build()
+		let request = try? builder.in(.system).toLogs(pod: "pod", container: nil, previous: false, timestamps: false, tailLines: nil).build()
 
-		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/api/v1/namespaces/kube-system/pods/pod/log")!)
+		XCTAssertEqual(request?.url, URL(string: "https://kubernetes/master/api/v1/namespaces/kube-system/pods/pod/log")!)
 		XCTAssertEqual(request?.method, HTTPMethod.GET)
 	}
 	
 	func testLogsWithContainerInNamespace() {
 		let builder = RequestBuilder(config: config, gvr: gvr)
-		let request = try? builder.in(.system).toLogs(pod: "pod", container: "container", previous: false, timestamps: false).build()
+		let request = try? builder.in(.system).toLogs(pod: "pod", container: "container", previous: false, timestamps: false, tailLines: nil).build()
 
-		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/api/v1/namespaces/kube-system/pods/pod/log?container=container")!)
+		XCTAssertEqual(request?.url, URL(string: "https://kubernetes/master/api/v1/namespaces/kube-system/pods/pod/log?container=container")!)
 		XCTAssertEqual(request?.method, HTTPMethod.GET)
 	}
 
 	func testLogsWithPreviousInNamespace() {
 		let builder = RequestBuilder(config: config, gvr: gvr)
-		let request = try? builder.in(.system).toLogs(pod: "pod", container: nil, previous: true, timestamps: false).build()
+		let request = try? builder.in(.system).toLogs(pod: "pod", container: nil, previous: true, timestamps: false, tailLines: nil).build()
 
-		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/api/v1/namespaces/kube-system/pods/pod/log?previous=true")!)
+		XCTAssertEqual(request?.url, URL(string: "https://kubernetes/master/api/v1/namespaces/kube-system/pods/pod/log?previous=true")!)
 		XCTAssertEqual(request?.method, HTTPMethod.GET)
 	}
 
 	func testLogsWithTimestampsInNamespace() {
 		let builder = RequestBuilder(config: config, gvr: gvr)
-		let request = try? builder.in(.system).toLogs(pod: "pod", container: nil, previous: false, timestamps: true).build()
+		let request = try? builder.in(.system).toLogs(pod: "pod", container: nil, previous: false, timestamps: true, tailLines: nil).build()
 
-		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/api/v1/namespaces/kube-system/pods/pod/log?timestamps=true")!)
+		XCTAssertEqual(request?.url, URL(string: "https://kubernetes/master/api/v1/namespaces/kube-system/pods/pod/log?timestamps=true")!)
 		XCTAssertEqual(request?.method, HTTPMethod.GET)
 	}
 
@@ -214,7 +214,7 @@ final class RequestBuilderTests: XCTestCase {
 		let builder = RequestBuilder(config: config, gvr: gvr)
 		let request = try? builder.in(.default).toGet().resource(withName: "test").subResource(.status).build()
 
-		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/api/v1/namespaces/default/pods/test/status")!)
+		XCTAssertEqual(request?.url, URL(string: "https://kubernetes/master/api/v1/namespaces/default/pods/test/status")!)
 		XCTAssertEqual(request?.method, HTTPMethod.GET)
 	}
 
@@ -222,7 +222,7 @@ final class RequestBuilderTests: XCTestCase {
 		let builder = RequestBuilder(config: config, gvr: gvr)
 		let request = try? builder.in(.default).toGet().resource(withName: "test").subResource(.scale).build()
 
-		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/api/v1/namespaces/default/pods/test/scale")!)
+		XCTAssertEqual(request?.url, URL(string: "https://kubernetes/master/api/v1/namespaces/default/pods/test/scale")!)
 		XCTAssertEqual(request?.method, HTTPMethod.GET)
 	}
 
@@ -230,12 +230,12 @@ final class RequestBuilderTests: XCTestCase {
 		let builder = RequestBuilder(config: config, gvr: gvr)
 		var request = try? builder.in(.default).toDelete().resource(withName: "test").build()
 
-		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/api/v1/namespaces/default/pods/test")!)
+		XCTAssertEqual(request?.url, URL(string: "https://kubernetes/master/api/v1/namespaces/default/pods/test")!)
 		XCTAssertEqual(request?.method, HTTPMethod.DELETE)
 
 		request = try? builder.in(.system).toDelete().build()
 
-		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/api/v1/namespaces/kube-system/pods/test")!)
+		XCTAssertEqual(request?.url, URL(string: "https://kubernetes/master/api/v1/namespaces/kube-system/pods/test")!)
 		XCTAssertEqual(request?.method, HTTPMethod.DELETE)
 	}
 
@@ -243,7 +243,7 @@ final class RequestBuilderTests: XCTestCase {
 		let builder = RequestBuilder(config: config, gvr: gvr)
 		let request = try? builder.in(.allNamespaces).toDelete().build()
 
-		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/api/v1/pods")!)
+		XCTAssertEqual(request?.url, URL(string: "https://kubernetes/master/api/v1/pods")!)
 		XCTAssertEqual(request?.method, HTTPMethod.DELETE)
 	}
 
@@ -252,7 +252,7 @@ final class RequestBuilderTests: XCTestCase {
 		let pod = sk.pod(name: "test")
 		let request = try? builder.in(.default).toPost().body(pod).build()
 
-		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/api/v1/namespaces/default/pods")!)
+		XCTAssertEqual(request?.url, URL(string: "https://kubernetes/master/api/v1/namespaces/default/pods")!)
 		XCTAssertEqual(request?.method, HTTPMethod.POST)
 	}
 
@@ -261,7 +261,7 @@ final class RequestBuilderTests: XCTestCase {
 		let pod = sk.pod(name: "test")
 		let request = try? builder.in(.default).toPut().resource(withName: "test").body(.resource(payload: pod)).build()
 
-		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/api/v1/namespaces/default/pods/test")!)
+		XCTAssertEqual(request?.url, URL(string: "https://kubernetes/master/api/v1/namespaces/default/pods/test")!)
 		XCTAssertEqual(request?.method, HTTPMethod.PUT)
 	}
 
@@ -270,7 +270,7 @@ final class RequestBuilderTests: XCTestCase {
 		let pod = sk.pod(name: "test")
 		let request = try? builder.in(.default).toPut().resource(withName: "test").body(.subResource(type: .status, payload: pod)).build()
 
-		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/api/v1/namespaces/default/pods/test/status")!)
+		XCTAssertEqual(request?.url, URL(string: "https://kubernetes/master/api/v1/namespaces/default/pods/test/status")!)
 		XCTAssertEqual(request?.method, HTTPMethod.PUT)
 	}
 
@@ -279,7 +279,7 @@ final class RequestBuilderTests: XCTestCase {
 		let pod = sk.pod(name: "test")
 		let request = try? builder.in(.default).toPut().resource(withName: "test").body(.subResource(type: .scale, payload: pod)).build()
 
-		XCTAssertEqual(request?.url, URL(string: "https://kubernetesmaster/api/v1/namespaces/default/pods/test/scale")!)
+		XCTAssertEqual(request?.url, URL(string: "https://kubernetes/master/api/v1/namespaces/default/pods/test/scale")!)
 		XCTAssertEqual(request?.method, HTTPMethod.PUT)
 	}
 }


### PR DESCRIPTION
This is a collection of tweaks that I've been running in production on Nautik for some time. Please let me know if you'd prefer getting them upstreamed as separate PRs instead of having them all cramped into one. In case it's okay like this, this PR does the following:

- Add client support for proxy URLs.
- Add client support for gzipped server responses.
- Add an optional `tailLines` parameter to the log request to be able to limit the number of lines requested from the server just like the upstream client does.
- Fix a bug on `RequestBuilder` where a path was overwritten where it should have been appended. This became apparent with users using Rancher, where the base path already had a `/` in it. This change fixed it for all types of clusters, Rancher or not, but please let me know if I'm missing something here.
- Add a `doesNotExist` variant to `LabelSelectorRequirement`, akin to the upstream "DoesNotExist" variant on selectors.
- Add the upstream `installHint`, `provideClusterInfo` and `interactiveMode` fields to `ExecConfig`.
- Make `ExecCredential` public, as we need it to roll [our own exec implementation](https://github.com/nautik-io/helper/blob/main/Nautik%20Helper/StoredCluster.swift#L133) that is probably too messy to ever be upstreamed.
- Add public initializers to `Cluster` and `AuthInfo` and make `Cluster`, `AuthInfo`, `AuthProviderConfig`, `ExecConfig` and `ExecEnvVar` conform to `Hashable` and `Equatable`, as we need to initialize and compare them in different places on the app. I hope this makes sense to upstream and doesn't interfere with anything you have in mind. Otherwise, please just let me know and I'll keep it downstream.