### PR TITLE
Added support for KUBECONFIG env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ client.shutdown(queue: queue) { (error: Error?) in
 
 The client tries to resolve a `kube config` automatically from different sources in the following order:
 
+- If set, kube config file at path of environment variable `KUBECONFIG`
 - Kube config file in the user's `$HOME/.kube/config` directory 
 - `ServiceAccount` token located at `/var/run/secrets/kubernetes.io/serviceaccount/token` and a mounted CA certificate, 
 - if it's running in Kubernetes.

--- a/Sources/SwiftkubeClient/Client/KubernetesClient.swift
+++ b/Sources/SwiftkubeClient/Client/KubernetesClient.swift
@@ -108,6 +108,7 @@ public actor KubernetesClient {
 	///
 	/// The client tries to resolve a `kube config` automatically from different sources in the following order:
 	///
+	/// - A Kube config file at path of environment variable `KUBECONFIG` (if set)
 	/// - A Kube config file in the user's `$HOME/.kube/config` directory
 	/// - `ServiceAccount` token located at `/var/run/secrets/kubernetes.io/serviceaccount/token` and a mounted CA certificate, if it's running in Kubernetes.
 	///


### PR DESCRIPTION
If set, the env variable KUBECONFIG is used to load a local kube config file. (see issue #33)