### PR TITLE
Make current version compile on iOS again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Unreleased]
+- Add guards so that the client is usable on iOS
+
 ## 0.25.0
 
 - Refactor configuration builders and add support for overriding the current k8s context (#47 by nefilim)

--- a/Sources/SwiftkubeClient/Client/KubernetesClient.swift
+++ b/Sources/SwiftkubeClient/Client/KubernetesClient.swift
@@ -104,6 +104,7 @@ public actor KubernetesClient {
 		}()
 	#endif
 
+	#if os(Linux) || os(macOS)
 	/// Create a new instance of the Kubernetes client.
 	///
 	/// The client tries to resolve a `kube config` automatically from different sources in the following order:
@@ -113,6 +114,9 @@ public actor KubernetesClient {
 	/// - `ServiceAccount` token located at `/var/run/secrets/kubernetes.io/serviceaccount/token` and a mounted CA certificate, if it's running in Kubernetes.
 	///
 	/// Returns `nil` if a configuration can't be found.
+	///
+	/// - Note: This initializer is only available on Linux and macOS. On iOS, tvOS, and watchOS, you must use
+	///         `init(config:provider:logger:)` with a manually configured `KubernetesClientConfig`.
 	///
 	/// - Parameters:
 	///    - provider: A ``EventLoopGroupProvider`` to specify how ``EventLoopGroup`` will be created.
@@ -129,6 +133,7 @@ public actor KubernetesClient {
 
 		self.init(config: config, provider: provider, logger: logger)
 	}
+	#endif
 
 	/// Create a new instance of the Kubernetes client.
 	///

--- a/Sources/SwiftkubeClient/Config/KubeConfig+Loaders.swift
+++ b/Sources/SwiftkubeClient/Config/KubeConfig+Loaders.swift
@@ -31,6 +31,7 @@ public extension KubeConfig {
 		return try from(config: contents)
 	}
 
+	#if os(Linux) || os(macOS)
 	static func fromEnvironment(envVar: String = "KUBECONFIG", logger: Logger? = nil) throws -> KubeConfig? {
 		guard let varContent = ProcessInfo.processInfo.environment[envVar] else {
 			logger?.info("Skipping kubeconfig because environment variable \(envVar) is not set")
@@ -43,7 +44,9 @@ public extension KubeConfig {
 
 		return try from(url: kubeConfigURL)
 	}
+	#endif
 
+	#if os(Linux) || os(macOS)
 	static func fromDefaultLocalConfig(logger: Logger? = nil) throws -> KubeConfig? {
 		guard let homePath = ProcessInfo.processInfo.environment["HOME"] else {
 			logger?.info("Skipping kubeconfig in $HOME/.kube/config because HOME env variable is not set.")
@@ -55,7 +58,9 @@ public extension KubeConfig {
 
 		return try from(url: kubeConfigURL)
 	}
+	#endif
 
+	#if os(Linux) || os(macOS)
 	static func fromServiceAccount(logger: Logger? = nil) throws -> KubeConfig? {
 		guard
 			let host = ProcessInfo.processInfo.environment["KUBERNETES_SERVICE_HOST"],
@@ -120,8 +125,10 @@ public extension KubeConfig {
 			currentContext: "service-account-context"
 		)
 	}
+	#endif
 }
 
+#if os(Linux) || os(macOS)
 internal extension String {
 
 	func stringByExpandingTildePath() -> String {
@@ -143,3 +150,4 @@ internal extension String {
 		return FileManager.default.homeDirectoryForCurrentUser.path + "/" + relativePath
 	}
 }
+#endif

--- a/Sources/SwiftkubeClient/Config/KubernetesClientConfig+Init.swift
+++ b/Sources/SwiftkubeClient/Config/KubernetesClientConfig+Init.swift
@@ -22,6 +22,7 @@ import Yams
 
 public extension KubernetesClientConfig {
 
+	#if os(Linux) || os(macOS)
 	/// Initializes a client configuration.
 	///
 	/// This factory method tries to resolve a `kube config` automatically from  different sources in the following order:
@@ -31,6 +32,9 @@ public extension KubernetesClientConfig {
 	/// - `ServiceAccount` token located at `/var/run/secrets/kubernetes.io/serviceaccount/token` and a mounted CA certificate, if it's running in Kubernetes.
 	///
 	/// It is also possible to override the default values for the underlying `HTTPClient` timeout and redirect config.
+	///
+	/// - Note: This method is only available on Linux and macOS. On iOS, tvOS, and watchOS, you must manually configure
+	///         the client using `KubernetesClientConfig.init()` or `from(kubeConfig:)`.
 	///
 	/// - Parameters:
 	///   - timeout: The desired timeout configuration to apply. If not provided, then `connect` timeout will  default to 10 seconds.
@@ -66,6 +70,7 @@ public extension KubernetesClientConfig {
 			logger: logger
 		)
 	}
+	#endif
 
 	/// Initializes a client configuration from a given KubeConfig using the specified `current-context`.
 	///


### PR DESCRIPTION
Hi,
as I'm currently building an app that runs on iPadOS with your nice framework, I had to patch it a little bit to make it run on iOS/iPadOS.
This patch merely makes sure that the autodiscovery on iOS and iPadOS is not triggered (because it won't work anyhow).
I added a part in the Readme as well.
